### PR TITLE
Fix empty PairClassification column in fas leaderboard

### DIFF
--- a/results/Alibaba-NLP__gte-multilingual-base/7fc06782350c1a83f88b15dd4b38ef853d3b8503/SynPerQAPC.json
+++ b/results/Alibaba-NLP__gte-multilingual-base/7fc06782350c1a83f88b15dd4b38ef853d3b8503/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/BAAI__bge-m3-unsupervised/46f03bc86361cf88102b0b517b36c8259f2946b1/SynPerQAPC.json
+++ b/results/BAAI__bge-m3-unsupervised/46f03bc86361cf88102b0b517b36c8259f2946b1/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/BAAI__bge-m3/5617a9f61b028005a4858fdac845db406aefb181/SynPerQAPC.json
+++ b/results/BAAI__bge-m3/5617a9f61b028005a4858fdac845db406aefb181/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/HooshvareLab__bert-base-parsbert-uncased/d73a0e2c7492c33bd5819bcdb23eba207404dd19/SynPerQAPC.json
+++ b/results/HooshvareLab__bert-base-parsbert-uncased/d73a0e2c7492c33bd5819bcdb23eba207404dd19/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/PartAI__Tooka-SBERT/5d07f0c543aca654373b931ae07cd197769110fd/SynPerQAPC.json
+++ b/results/PartAI__Tooka-SBERT/5d07f0c543aca654373b931ae07cd197769110fd/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/PartAI__TookaBERT-Base/fa5ca89df5670700d9325b8872ac65c17cb24582/SynPerQAPC.json
+++ b/results/PartAI__TookaBERT-Base/fa5ca89df5670700d9325b8872ac65c17cb24582/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/intfloat__multilingual-e5-base/d13f1b27baf31030b7fd040960d60d909913633f/SynPerQAPC.json
+++ b/results/intfloat__multilingual-e5-base/d13f1b27baf31030b7fd040960d60d909913633f/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/intfloat__multilingual-e5-large/ab10c1a7f42e74530fe7ae5be82e6d4f11a719eb/SynPerQAPC.json
+++ b/results/intfloat__multilingual-e5-large/ab10c1a7f42e74530fe7ae5be82e6d4f11a719eb/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/jinaai__jina-embeddings-v3/215a6e121fa0183376388ac6b1ae230326bfeaed/SynPerQAPC.json
+++ b/results/jinaai__jina-embeddings-v3/215a6e121fa0183376388ac6b1ae230326bfeaed/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/m3hrdadfi__bert-zwnj-wnli-mean-tokens/b9506ddc579ac8c398ae6dae680401ae0a1a5b23/SynPerQAPC.json
+++ b/results/m3hrdadfi__bert-zwnj-wnli-mean-tokens/b9506ddc579ac8c398ae6dae680401ae0a1a5b23/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/m3hrdadfi__roberta-zwnj-wnli-mean-tokens/36f912ac44e22250aee16ea533a4ff8cd848c1a1/SynPerQAPC.json
+++ b/results/m3hrdadfi__roberta-zwnj-wnli-mean-tokens/36f912ac44e22250aee16ea533a4ff8cd848c1a1/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/myrkur__sentence-transformer-parsbert-fa/72bd0a3557622f0ae08a092f4643609e0b950cdd/SynPerQAPC.json
+++ b/results/myrkur__sentence-transformer-parsbert-fa/72bd0a3557622f0ae08a092f4643609e0b950cdd/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/sbunlp__fabert/a0e3973064c97768e121b9b95f21adc94e0ca3fb/SynPerQAPC.json
+++ b/results/sbunlp__fabert/a0e3973064c97768e121b9b95f21adc94e0ca3fb/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/sentence-transformers__LaBSE/e34fab64a3011d2176c99545a93d5cbddc9a91b7/SynPerQAPC.json
+++ b/results/sentence-transformers__LaBSE/e34fab64a3011d2176c99545a93d5cbddc9a91b7/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [

--- a/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/bf3bf13ab40c3157080a7ab344c831b9ad18b5eb/SynPerQAPC.json
+++ b/results/sentence-transformers__paraphrase-multilingual-MiniLM-L12-v2/bf3bf13ab40c3157080a7ab344c831b9ad18b5eb/SynPerQAPC.json
@@ -1,6 +1,6 @@
 {
   "dataset_revision": "d1b62ef31bebbb48ae01867993a1e583c2ce7d93",
-  "task_name": "SynPerQAFaPC",
+  "task_name": "SynPerQAPC",
   "mteb_version": "1.25.8",
   "scores": {
     "test": [


### PR DESCRIPTION
## Description
This PR fixes an issue where the PairClassification score for the Persian task (SynPerQAPC) was not being displayed on the leaderboard.
 
## Cause
The issue was due to incorrect task_name values in several JSON result files. Because of this mismatch, the leaderboard pipeline could not correctly associate the results with the Persian PairClassification task.

## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the results files checker `make pre-push`.