### PR TITLE
add missing split in HUMEMultilingualSentimentClassification

### DIFF
--- a/results/google__embeddinggemma-300m/64614b0b8b64f0c6c1e52b07e4e9a4e8fe4d2da2/HUMEMultilingualSentimentClassification.json
+++ b/results/google__embeddinggemma-300m/64614b0b8b64f0c6c1e52b07e4e9a4e8fe4d2da2/HUMEMultilingualSentimentClassification.json
@@ -1,7 +1,7 @@
 {
   "dataset_revision": "1b988d30980efdd9c27de1643837bf3ae5bae814",
   "task_name": "HUMEMultilingualSentimentClassification",
-  "mteb_version": "1.38.49",
+  "mteb_version": "1.39.6",
   "scores": {
     "test": [
       {
@@ -173,6 +173,90 @@
         ]
       },
       {
+        "accuracy": 0.54,
+        "f1": 0.530802,
+        "f1_weighted": 0.530802,
+        "ap": 0.537078,
+        "ap_weighted": 0.537078,
+        "scores_per_experiment": [
+          {
+            "accuracy": 0.725,
+            "f1": 0.724828,
+            "f1_weighted": 0.724828,
+            "ap": 0.665789,
+            "ap_weighted": 0.665789
+          },
+          {
+            "accuracy": 0.45,
+            "f1": 0.444444,
+            "f1_weighted": 0.444444,
+            "ap": 0.478125,
+            "ap_weighted": 0.478125
+          },
+          {
+            "accuracy": 0.625,
+            "f1": 0.624765,
+            "f1_weighted": 0.624765,
+            "ap": 0.578947,
+            "ap_weighted": 0.578947
+          },
+          {
+            "accuracy": 0.475,
+            "f1": 0.458414,
+            "f1_weighted": 0.458414,
+            "ap": 0.487963,
+            "ap_weighted": 0.487963
+          },
+          {
+            "accuracy": 0.35,
+            "f1": 0.335038,
+            "f1_weighted": 0.335038,
+            "ap": 0.457143,
+            "ap_weighted": 0.457143
+          },
+          {
+            "accuracy": 0.45,
+            "f1": 0.427083,
+            "f1_weighted": 0.427083,
+            "ap": 0.476786,
+            "ap_weighted": 0.476786
+          },
+          {
+            "accuracy": 0.675,
+            "f1": 0.674797,
+            "f1_weighted": 0.674797,
+            "ap": 0.616667,
+            "ap_weighted": 0.616667
+          },
+          {
+            "accuracy": 0.475,
+            "f1": 0.474672,
+            "f1_weighted": 0.474672,
+            "ap": 0.488095,
+            "ap_weighted": 0.488095
+          },
+          {
+            "accuracy": 0.7,
+            "f1": 0.69697,
+            "f1_weighted": 0.69697,
+            "ap": 0.633333,
+            "ap_weighted": 0.633333
+          },
+          {
+            "accuracy": 0.475,
+            "f1": 0.447005,
+            "f1_weighted": 0.447005,
+            "ap": 0.487931,
+            "ap_weighted": 0.487931
+          }
+        ],
+        "main_score": 0.54,
+        "hf_subset": "nor",
+        "languages": [
+          "nob-Latn"
+        ]
+      },
+      {
         "accuracy": 0.735,
         "f1": 0.730336,
         "f1_weighted": 0.730336,
@@ -258,6 +342,6 @@
       }
     ]
   },
-  "evaluation_time": 72.02458310127258,
+  "evaluation_time": 56.817699670791626,
   "kg_co2_emissions": null
 }


### PR DESCRIPTION
<!-- Description of the PR goes here -->

### Checklist

- [ ] My model has a model sheet, report or similar
- [ ] My model has a reference implementation in [`mteb/models/`](https://github.com/embeddings-benchmark/mteb/tree/main/mteb/models) this can be as an API. Instruction on how to add a model can be found [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md) 
  - [ ] No, but there is an existing PR ___
- [ ] The results submitted is obtained using the reference implementation
- [ ] My model is available, either as a publicly accessible API or publicly on e.g., Huggingface
- [ ] I *solemnly swear* that for all results submitted I have not trained on the evaluation dataset including training splits. If I have I have disclosed it clearly.

