### PR TITLE
Generate cached results

### DIFF
--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -1,0 +1,78 @@
+name: Generate Cached Results
+
+on:
+  push:
+    branches: [main]
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+jobs:
+  generate-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          docker system prune -af
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mteb>=2.0
+
+      - name: Generate cached results
+        run: |
+          cd scripts
+          python generate_cached_results.py
+        env:
+          PYTHONUNBUFFERED: 1
+
+      - name: Check if cached results changed
+        id: check_changes
+        run: |
+          if [ -f "__cached_results.json" ]; then
+            git add __cached_results.json
+            if git diff --cached --quiet; then
+              echo "changes=false" >> $GITHUB_OUTPUT
+              echo "No changes to cached results"
+            else
+              echo "changes=true" >> $GITHUB_OUTPUT
+              echo "Cached results have changed"
+            fi
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "No cached results file generated"
+          fi
+
+      - name: Commit and push cached results
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add __cached_results.json
+          git commit -m "chore: update cached results [skip ci]"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report file size
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          if [ -f "__cached_results.json" ]; then
+            ls -lh __cached_results.json
+            echo "Cached results file size: $(du -h __cached_results.json | cut -f1)"
+          fi

--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -39,55 +39,52 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
 
-      - name: Create uncompressed version for leaderboard app
+      - name: Configure Git
         run: |
-          if [ -f "__cached_results.json.gz" ]; then
-            # Create mteb/leaderboard directory if it doesn't exist
-            mkdir -p mteb/leaderboard
-            # Decompress the gzip file to the leaderboard directory for app.py compatibility
-            gunzip -c __cached_results.json.gz > mteb/leaderboard/__cached_results.json
-            echo "✅ Created uncompressed cache file for leaderboard app"
-          else
-            echo "❌ Compressed cache file not found"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update cached-data branch
+        run: |
+          # Check if __cached_results.json.gz was created
+          if [ ! -f "__cached_results.json.gz" ]; then
+            echo "❌ Cached results file not found"
             exit 1
           fi
 
-      - name: Check if cached results changed
-        id: check_changes
-        run: |
-          if [ -f "__cached_results.json.gz" ] && [ -f "mteb/leaderboard/__cached_results.json" ]; then
-            git add __cached_results.json.gz mteb/leaderboard/__cached_results.json
-            if git diff --cached --quiet; then
-              echo "changes=false" >> $GITHUB_OUTPUT
-              echo "No changes to cached results"
-            else
-              echo "changes=true" >> $GITHUB_OUTPUT
-              echo "Cached results have changed"
-            fi
+          # Get file size for logging
+          FILE_SIZE=$(stat -f%z __cached_results.json.gz 2>/dev/null || stat -c%s __cached_results.json.gz)
+          echo "📦 Generated cache file: $(echo "scale=1; $FILE_SIZE/1024/1024" | bc -l)MB"
+
+          # Switch to cached-data branch (create if doesn't exist)
+          git checkout --orphan cached-data 2>/dev/null || git checkout cached-data
+
+          # Remove all files except the cached results
+          git rm -rf . 2>/dev/null || true
+
+          # Add only the cached results file
+          git add __cached_results.json.gz
+
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "✅ No changes in cached results, skipping commit"
           else
-            echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No cached results files generated"
+            # Commit with timestamp and file size
+            TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            COMMIT_MSG="Update cached results - $TIMESTAMP ($(echo "scale=1; $FILE_SIZE/1024/1024" | bc -l)MB)"
+            git commit -m "$COMMIT_MSG"
+
+            # Push to remote
+            git push origin cached-data
+            echo "✅ Successfully updated cached-data branch"
           fi
 
-      - name: Commit and push cached results
-        if: steps.check_changes.outputs.changes == 'true'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add __cached_results.json.gz mteb/leaderboard/__cached_results.json
-          git commit -m "chore: update cached results [skip ci]"
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Report file size
-        if: steps.check_changes.outputs.changes == 'true'
+      - name: Report status
+        if: always()
         run: |
           if [ -f "__cached_results.json.gz" ]; then
-            echo "📦 Compressed cache (repo root): $(du -h __cached_results.json.gz | cut -f1)"
-            ls -lh __cached_results.json.gz
-          fi
-          if [ -f "mteb/leaderboard/__cached_results.json" ]; then
-            echo "📄 Uncompressed cache (leaderboard): $(du -h mteb/leaderboard/__cached_results.json | cut -f1)"
-            ls -lh mteb/leaderboard/__cached_results.json
+            FILE_SIZE=$(stat -f%z __cached_results.json.gz 2>/dev/null || stat -c%s __cached_results.json.gz)
+            echo "✅ Workflow completed. Cache file size: $(echo "scale=1; $FILE_SIZE/1024/1024" | bc -l)MB"
+          else
+            echo "❌ Workflow failed - no cache file generated"
           fi

--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -31,13 +31,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install mteb>=2.0
+           pip install git+https://github.com/embeddings-benchmark/mteb.git
 
       - name: Generate cached results
         run: |
-          cd scripts
-          python generate_cached_results.py
+          python scripts/generate_cached_results.py
         env:
           PYTHONUNBUFFERED: 1
 

--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -59,8 +59,8 @@ jobs:
           # Switch to cached-data branch (create if doesn't exist)
           git checkout --orphan cached-data 2>/dev/null || git checkout cached-data
 
-          # Remove all files except the cached results
-          git rm -rf . 2>/dev/null || true
+          # Remove all files except README.md and the cached results
+          git ls-files | grep -v "README.md" | grep -v "__cached_results.json.gz" | xargs -r git rm 2>/dev/null || true
 
           # Add only the cached results file
           git add __cached_results.json.gz

--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Check if cached results changed
         id: check_changes
         run: |
-          if [ -f "__cached_results.json" ]; then
-            git add __cached_results.json
+          if [ -f "__cached_results.json.gz" ]; then
+            git add __cached_results.json.gz
             if git diff --cached --quiet; then
               echo "changes=false" >> $GITHUB_OUTPUT
               echo "No changes to cached results"
@@ -63,7 +63,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add __cached_results.json
+          git add __cached_results.json.gz
           git commit -m "chore: update cached results [skip ci]"
           git push
         env:
@@ -72,7 +72,7 @@ jobs:
       - name: Report file size
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          if [ -f "__cached_results.json" ]; then
-            ls -lh __cached_results.json
-            echo "Cached results file size: $(du -h __cached_results.json | cut -f1)"
+          if [ -f "__cached_results.json.gz" ]; then
+            ls -lh __cached_results.json.gz
+            echo "Cached results file size: $(du -h __cached_results.json.gz | cut -f1)"
           fi

--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -39,11 +39,24 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
 
+      - name: Create uncompressed version for leaderboard app
+        run: |
+          if [ -f "__cached_results.json.gz" ]; then
+            # Create mteb/leaderboard directory if it doesn't exist
+            mkdir -p mteb/leaderboard
+            # Decompress the gzip file to the leaderboard directory for app.py compatibility
+            gunzip -c __cached_results.json.gz > mteb/leaderboard/__cached_results.json
+            echo "✅ Created uncompressed cache file for leaderboard app"
+          else
+            echo "❌ Compressed cache file not found"
+            exit 1
+          fi
+
       - name: Check if cached results changed
         id: check_changes
         run: |
-          if [ -f "__cached_results.json.gz" ]; then
-            git add __cached_results.json.gz
+          if [ -f "__cached_results.json.gz" ] && [ -f "mteb/leaderboard/__cached_results.json" ]; then
+            git add __cached_results.json.gz mteb/leaderboard/__cached_results.json
             if git diff --cached --quiet; then
               echo "changes=false" >> $GITHUB_OUTPUT
               echo "No changes to cached results"
@@ -53,7 +66,7 @@ jobs:
             fi
           else
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No cached results file generated"
+            echo "No cached results files generated"
           fi
 
       - name: Commit and push cached results
@@ -61,7 +74,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add __cached_results.json.gz
+          git add __cached_results.json.gz mteb/leaderboard/__cached_results.json
           git commit -m "chore: update cached results [skip ci]"
           git push
         env:
@@ -71,6 +84,10 @@ jobs:
         if: steps.check_changes.outputs.changes == 'true'
         run: |
           if [ -f "__cached_results.json.gz" ]; then
+            echo "📦 Compressed cache (repo root): $(du -h __cached_results.json.gz | cut -f1)"
             ls -lh __cached_results.json.gz
-            echo "Cached results file size: $(du -h __cached_results.json.gz | cut -f1)"
+          fi
+          if [ -f "mteb/leaderboard/__cached_results.json" ]; then
+            echo "📄 Uncompressed cache (leaderboard): $(du -h mteb/leaderboard/__cached_results.json | cut -f1)"
+            ls -lh mteb/leaderboard/__cached_results.json
           fi

--- a/scripts/generate_cached_results.py
+++ b/scripts/generate_cached_results.py
@@ -35,7 +35,7 @@ def generate_cached_results():
     start_time = time.time()
     
     logger.info("Initializing ResultCache...")
-    cache = ResultCache()
+    cache = ResultCache(Path(__file__).parent.parent)
     
     # The remote repo should already be cloned from previous runs
     logger.info("Using existing remote results repository...")

--- a/scripts/generate_cached_results.py
+++ b/scripts/generate_cached_results.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Script to generate __cached_results.json for the MTEB leaderboard.
+
+This pre-generates the cached results file that the leaderboard uses,
+which can save 100+ seconds on fresh leaderboard builds.
+
+Usage:
+    python generate_cached_results.py
+
+Output:
+    Creates __cached_results.json in the remote repo root directory
+"""
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import mteb
+from mteb.cache import ResultCache
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] %(levelname)s - %(message)s',
+    datefmt='%H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+
+def generate_cached_results():
+    """Generate the cached results JSON file."""
+    start_time = time.time()
+    
+    logger.info("Initializing ResultCache...")
+    cache = ResultCache()
+    
+    # The remote repo should already be cloned from previous runs
+    logger.info("Using existing remote results repository...")
+    
+    # Load all model names
+    logger.info("Getting all model names...")
+    models_start = time.time()
+    all_model_names = [model_meta.name for model_meta in mteb.get_model_metas()]
+    models_time = time.time() - models_start
+    logger.info(f"Found {len(all_model_names)} models in {models_time:.2f}s")
+    
+    # Load results for all models
+    logger.info("Loading results from cache...")
+    load_start = time.time()
+    all_results = cache.load_results(
+        models=all_model_names,
+        only_main_score=True,
+        require_model_meta=False,
+        include_remote=True,
+    )
+    load_time = time.time() - load_start
+    logger.info(f"Loaded results in {load_time:.2f}s")
+    
+    # Serialize to JSON
+    logger.info("Serializing to JSON...")
+    serialize_start = time.time()
+    results_dict = all_results.model_dump(mode='json')
+    serialize_time = time.time() - serialize_start
+    logger.info(f"Serialized in {serialize_time:.2f}s")
+    
+    # Write to file in remote repo root directory
+    repo_root = Path(__file__).parent.parent
+    output_path = repo_root / "__cached_results.json"
+    logger.info(f"Writing to {output_path}...")
+    write_start = time.time()
+    with output_path.open('w') as f:
+        json.dump(results_dict, f, indent=None, separators=(',', ':'))
+    write_time = time.time() - write_start
+    logger.info(f"Written in {write_time:.2f}s")
+    
+    # Report file size
+    file_size_mb = output_path.stat().st_size / (1024 * 1024)
+    logger.info(f"Generated {output_path} ({file_size_mb:.1f} MB)")
+    
+    total_time = time.time() - start_time
+    logger.info(f"Total time: {total_time:.2f}s")
+    
+    return output_path
+
+
+if __name__ == "__main__":
+    try:
+        output_file = generate_cached_results()
+        logger.info(f"✅ Success! Generated {output_file}")
+    except Exception as e:
+        logger.error(f"❌ Failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/scripts/generate_cached_results.py
+++ b/scripts/generate_cached_results.py
@@ -59,23 +59,16 @@ def generate_cached_results():
     load_time = time.time() - load_start
     logger.info(f"Loaded results in {load_time:.2f}s")
     
-    # Serialize to JSON
-    logger.info("Serializing to JSON...")
-    serialize_start = time.time()
-    results_dict = all_results.model_dump(mode='json')
-    serialize_time = time.time() - serialize_start
-    logger.info(f"Serialized in {serialize_time:.2f}s")
-    
-    # Write to gzip file in remote repo root directory
+    # Serialize to JSON and write to gzip file
     repo_root = Path(__file__).parent.parent
     output_path = repo_root / "__cached_results.json.gz"
-    logger.info(f"Writing to {output_path}...")
+    logger.info(f"Serializing to JSON and writing to {output_path}...")
     write_start = time.time()
-    json_str = json.dumps(results_dict, separators=(',', ':'))
+    json_str = all_results.model_dump_json()
     with gzip.open(output_path, 'wt', encoding='utf-8') as f:
         f.write(json_str)
     write_time = time.time() - write_start
-    logger.info(f"Written in {write_time:.2f}s")
+    logger.info(f"Serialized and written in {write_time:.2f}s")
     
     # Report file size
     file_size_mb = output_path.stat().st_size / (1024 * 1024)


### PR DESCRIPTION
  ## Summary
  Adds infrastructure to pre-generate a compressed cache file containing all benchmark results, which can save **100+ seconds** on leaderboard startup times for fresh
  builds.

  ## Changes
  - **Generation script**: Creates `__cached_results.json.gz` by loading all model results and serializing to a gzipped JSON file
  - **GitHub Actions workflow**: Automatically regenerates the cache file on every merge to main
  - **Compression**: Uses gzip to reduce file size by ~80-90% (from ~670MB to ~70-100MB)

  ## Performance Impact
  - **Loading results**: 126s (current) → <10s (with pre-generated cache)
  - **Total savings**: 100+ seconds on fresh leaderboard builds
  - **File size**: ~670MB uncompressed → ~70-100MB compressed

  ## Workflow Behavior
  - Triggers on push to `main` branch
  - Runs generation script with full MTEB installation
  - Only commits if cached results changed
  - Uses `[skip ci]` to prevent infinite loops
  - Can be manually triggered via `workflow_dispatch`