### PR TITLE
Add Git LFS support for large cache files in GitHub Actions workflow

### DIFF
--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          lfs: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -39,9 +40,13 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
 
-      - name: Setup Git LFS
+      - name: Install Git LFS
         run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
           git lfs install
+          # Explicitly pull LFS files to work around checkout action issues
+          git lfs pull || true
 
       - name: Configure Git
         run: |
@@ -70,6 +75,8 @@ jobs:
             echo "📋 Switching to existing cached-data branch"
             git checkout cached-data
             git pull origin cached-data
+            # Ensure LFS files are available after branch checkout
+            git lfs pull || true
           else
             echo "🆕 Creating new cached-data branch"
             git checkout --orphan cached-data
@@ -85,26 +92,27 @@ jobs:
           # Setup Git LFS tracking for the cache file (if not already tracked)
           if ! git lfs ls-files | grep -q "__cached_results.json.gz"; then
             git lfs track "__cached_results.json.gz"
-            # Add .gitattributes if it was created
-            if [ -f ".gitattributes" ]; then
-              git add .gitattributes
-            fi
           fi
 
           # Ensure we only have the files we want
-          # Remove all tracked files except README.md
+          # Remove all tracked files except README.md and .gitattributes
           if [ -f "README.md" ]; then
-            git ls-files | grep -v "README.md" | xargs -r git rm 2>/dev/null || true
+            git ls-files | grep -v "README.md" | grep -v ".gitattributes" | xargs -r git rm 2>/dev/null || true
           else
-            git ls-files | xargs -r git rm 2>/dev/null || true
+            git ls-files | grep -v ".gitattributes" | xargs -r git rm 2>/dev/null || true
           fi
 
-          # Add only the cached results file
+          # Add the cached results file (will be tracked by LFS)
           git add __cached_results.json.gz
 
           # Preserve README.md if it exists in the working directory
           if [ -f "README.md" ]; then
             git add README.md
+          fi
+
+          # Add .gitattributes file (required for LFS tracking)
+          if [ -f ".gitattributes" ]; then
+            git add .gitattributes
           fi
 
           # Check if there are changes to commit
@@ -114,7 +122,7 @@ jobs:
             # Verify we're not committing too many files (safety check)
             STAGED_FILES=$(git diff --staged --name-only | wc -l)
             if [ "$STAGED_FILES" -gt 10 ]; then
-              echo "❌ ERROR: Too many files staged ($STAGED_FILES). Expected only 1-3 files (.gitattributes, __cached_results.json.gz, README.md)."
+              echo "❌ ERROR: Too many files staged ($STAGED_FILES). Expected only 1-3 files (__cached_results.json.gz, README.md, .gitattributes)."
               echo "Staged files:"
               git diff --staged --name-only
               exit 1

--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -39,6 +39,10 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
 
+      - name: Setup Git LFS
+        run: |
+          git lfs install
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -78,6 +82,15 @@ jobs:
             mv __cached_results.json.gz.tmp __cached_results.json.gz
           fi
 
+          # Setup Git LFS tracking for the cache file (if not already tracked)
+          if ! git lfs ls-files | grep -q "__cached_results.json.gz"; then
+            git lfs track "__cached_results.json.gz"
+            # Add .gitattributes if it was created
+            if [ -f ".gitattributes" ]; then
+              git add .gitattributes
+            fi
+          fi
+
           # Ensure we only have the files we want
           # Remove all tracked files except README.md
           if [ -f "README.md" ]; then
@@ -101,7 +114,7 @@ jobs:
             # Verify we're not committing too many files (safety check)
             STAGED_FILES=$(git diff --staged --name-only | wc -l)
             if [ "$STAGED_FILES" -gt 10 ]; then
-              echo "❌ ERROR: Too many files staged ($STAGED_FILES). Expected only 1-2 files."
+              echo "❌ ERROR: Too many files staged ($STAGED_FILES). Expected only 1-3 files (.gitattributes, __cached_results.json.gz, README.md)."
               echo "Staged files:"
               git diff --staged --name-only
               exit 1
@@ -112,7 +125,7 @@ jobs:
             COMMIT_MSG="Update cached results - $TIMESTAMP ($(echo "scale=1; $FILE_SIZE/1024/1024" | bc -l)MB)"
             git commit -m "$COMMIT_MSG"
 
-            # Push to remote
+            # Push to remote (LFS will handle the large file automatically)
             git push origin cached-data
             echo "✅ Successfully updated cached-data branch"
           fi


### PR DESCRIPTION
This commit addresses the GitHub file size warnings by integrating Git LFS support for the 88.4MB __cached_results.json.gz cache file.

## Problem
The cached results file (88.4MB) exceeds GitHub's 50MB recommendation, causing warnings during push operations:
```
remote: warning: File __cached_results.json.gz is 88.41 MB; this is larger
than GitHub's recommended maximum file size of 50.00 MB
```

## Solution: Git LFS Integration
- **Git LFS Installation**: Added setup step to install Git LFS in the workflow
- **Automatic LFS Tracking**: Configured automatic tracking of __cached_results.json.gz
- **Safe .gitattributes Management**: Added logic to commit .gitattributes when created
- **Enhanced Safety Checks**: Updated file count validation to account for LFS files

## Technical Implementation
1. **LFS Setup**: `git lfs install` runs before any git operations
2. **Smart Tracking**: Only tracks the cache file if not already tracked
3. **Seamless Integration**: LFS operations are transparent to existing workflow
4. **Safety First**: Enhanced validation prevents committing unexpected files

## Benefits
- ✅ Eliminates large file warnings
- ✅ Faster clone/pull operations for users
- ✅ Maintains existing workflow behavior
- ✅ No impact on cache file functionality
- ✅ Automatic LFS handling during push operations

The workflow now properly handles large cache files while maintaining all existing safety checks and conflict resolution mechanisms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


