### PR TITLE
Fix LFS budget error by skipping smudge and removing .gitattributes

### DIFF
--- a/.github/workflows/generate_cached_results.yml
+++ b/.github/workflows/generate_cached_results.yml
@@ -45,6 +45,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update cached-data branch
+        env:
+          GIT_LFS_SKIP_SMUDGE: "1"
         run: |
           # Check if __cached_results.json.gz was created
           if [ ! -f "__cached_results.json.gz" ]; then
@@ -66,6 +68,12 @@ jobs:
             echo "📋 Switching to existing cached-data branch"
             git checkout cached-data
             git pull origin cached-data
+
+            # Remove .gitattributes to clean up LFS tracking (one-time migration)
+            if [ -f ".gitattributes" ]; then
+              echo "🧹 Removing .gitattributes (LFS cleanup)"
+              git rm .gitattributes 2>/dev/null || rm -f .gitattributes
+            fi
           else
             echo "🆕 Creating new cached-data branch"
             git checkout --orphan cached-data


### PR DESCRIPTION
## Summary
- Adds `GIT_LFS_SKIP_SMUDGE=1` to prevent LFS download during checkout
- Removes `.gitattributes` from cached-data branch (one-time cleanup)

Fixes the workflow failure caused by LFS budget exceeded error after PR #397 was merged.

## Test plan
- [ ] Workflow runs successfully after merge
- [ ] cached-data branch no longer has `.gitattributes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)