### PR TITLE
fix: set main score to LRAP instead of accuracy for multilabel clf audio tasks

### DIFF
--- a/results/LCO-Embedding__LCO-Embedding-Omni-3B/eea763cfaf673e955ae86c64968896a3fea70189/BirdSet.json
+++ b/results/LCO-Embedding__LCO-Embedding-Omni-3B/eea763cfaf673e955ae86c64968896a3fea70189/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.270639,
         "f1": 0.037509,
         "hamming": 0.036672,
-        "main_score": 0.030503,
+        "main_score": 0.270639,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/LCO-Embedding__LCO-Embedding-Omni-3B/eea763cfaf673e955ae86c64968896a3fea70189/FSD2019Kaggle.json
+++ b/results/LCO-Embedding__LCO-Embedding-Omni-3B/eea763cfaf673e955ae86c64968896a3fea70189/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.740538,
         "f1": 0.590214,
         "hamming": 0.520795,
-        "main_score": 0.429659,
+        "main_score": 0.740538,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.452694,
         "f1": 0.258043,
         "hamming": 0.205105,
-        "main_score": 0.14133,
+        "main_score": 0.452694,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/LCO-Embedding__LCO-Embedding-Omni-3B/eea763cfaf673e955ae86c64968896a3fea70189/FSD50K.json
+++ b/results/LCO-Embedding__LCO-Embedding-Omni-3B/eea763cfaf673e955ae86c64968896a3fea70189/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.84525,
         "f1": 0.58413,
         "hamming": 0.627666,
-        "main_score": 0.042188,
+        "main_score": 0.84525,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/LCO-Embedding__LCO-Embedding-Omni-7B/3d38f58aae1253a4443b1270b0767f1e533936cf/BirdSet.json
+++ b/results/LCO-Embedding__LCO-Embedding-Omni-7B/3d38f58aae1253a4443b1270b0767f1e533936cf/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.267262,
         "f1": 0.036918,
         "hamming": 0.036285,
-        "main_score": 0.030341,
+        "main_score": 0.267262,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/LCO-Embedding__LCO-Embedding-Omni-7B/3d38f58aae1253a4443b1270b0767f1e533936cf/FSD2019Kaggle.json
+++ b/results/LCO-Embedding__LCO-Embedding-Omni-7B/3d38f58aae1253a4443b1270b0767f1e533936cf/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.757366,
         "f1": 0.602071,
         "hamming": 0.533886,
-        "main_score": 0.441866,
+        "main_score": 0.757366,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.463565,
         "f1": 0.264261,
         "hamming": 0.209715,
-        "main_score": 0.145369,
+        "main_score": 0.463565,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/LCO-Embedding__LCO-Embedding-Omni-7B/3d38f58aae1253a4443b1270b0767f1e533936cf/FSD50K.json
+++ b/results/LCO-Embedding__LCO-Embedding-Omni-7B/3d38f58aae1253a4443b1270b0767f1e533936cf/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.850253,
         "f1": 0.589923,
         "hamming": 0.632912,
-        "main_score": 0.049023,
+        "main_score": 0.850253,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/MIT__ast-finetuned-audioset-10-10-0.4593/f826b80d28226b62986cc218e5cec390b1096902/BirdSet.json
+++ b/results/MIT__ast-finetuned-audioset-10-10-0.4593/f826b80d28226b62986cc218e5cec390b1096902/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.370502,
         "f1": 0.069129,
         "hamming": 0.075854,
-        "main_score": 0.065463,
+        "main_score": 0.370502,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/MIT__ast-finetuned-audioset-10-10-0.4593/f826b80d28226b62986cc218e5cec390b1096902/FSD2019Kaggle.json
+++ b/results/MIT__ast-finetuned-audioset-10-10-0.4593/f826b80d28226b62986cc218e5cec390b1096902/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.726825,
         "f1": 0.527082,
         "hamming": 0.443899,
-        "main_score": 0.369025,
+        "main_score": 0.726825,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.460099,
         "f1": 0.209038,
         "hamming": 0.15444,
-        "main_score": 0.116269,
+        "main_score": 0.460099,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/MIT__ast-finetuned-audioset-10-10-0.4593/f826b80d28226b62986cc218e5cec390b1096902/FSD50K.json
+++ b/results/MIT__ast-finetuned-audioset-10-10-0.4593/f826b80d28226b62986cc218e5cec390b1096902/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.846663,
         "f1": 0.545123,
         "hamming": 0.619311,
-        "main_score": 0.027881,
+        "main_score": 0.846663,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/OpenMuQ__MuQ-MuLan-large/8a081dbcf84edd47ea7db3c4ecb8fd1ec1ddacfe/BirdSet.json
+++ b/results/OpenMuQ__MuQ-MuLan-large/8a081dbcf84edd47ea7db3c4ecb8fd1ec1ddacfe/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.159485,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.159485,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/OpenMuQ__MuQ-MuLan-large/8a081dbcf84edd47ea7db3c4ecb8fd1ec1ddacfe/FSD2019Kaggle.json
+++ b/results/OpenMuQ__MuQ-MuLan-large/8a081dbcf84edd47ea7db3c4ecb8fd1ec1ddacfe/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.330777,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.330777,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.194922,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.194922,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/OpenMuQ__MuQ-MuLan-large/8a081dbcf84edd47ea7db3c4ecb8fd1ec1ddacfe/FSD50K.json
+++ b/results/OpenMuQ__MuQ-MuLan-large/8a081dbcf84edd47ea7db3c4ecb8fd1ec1ddacfe/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.842707,
         "f1": 0.296129,
         "hamming": 0.598569,
-        "main_score": 0.0,
+        "main_score": 0.842707,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/Qwen__Qwen2-Audio-7B/dd84470756e6277a71d4d7188773a43cde92696e/BirdSet.json
+++ b/results/Qwen__Qwen2-Audio-7B/dd84470756e6277a71d4d7188773a43cde92696e/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.177522,
         "f1": 0.012279,
         "hamming": 0.015413,
-        "main_score": 0.008102,
+        "main_score": 0.177522,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/Qwen__Qwen2-Audio-7B/dd84470756e6277a71d4d7188773a43cde92696e/FSD2019Kaggle.json
+++ b/results/Qwen__Qwen2-Audio-7B/dd84470756e6277a71d4d7188773a43cde92696e/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.3264,
         "f1": 0.156463,
         "hamming": 0.110314,
-        "main_score": 0.070475,
+        "main_score": 0.3264,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.143749,
         "f1": 0.049234,
         "hamming": 0.030842,
-        "main_score": 0.016737,
+        "main_score": 0.143749,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/Qwen__Qwen2-Audio-7B/dd84470756e6277a71d4d7188773a43cde92696e/FSD50K.json
+++ b/results/Qwen__Qwen2-Audio-7B/dd84470756e6277a71d4d7188773a43cde92696e/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.685676
           }
         ],
-        "main_score": 0.137839,
+        "main_score": 0.682722,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-base-plus-400k-ft-ls100h/d78e7a1b50e9f1ce21887ca069330efdd5ccd4ca/BirdSet.json
+++ b/results/asapp__sew-d-base-plus-400k-ft-ls100h/d78e7a1b50e9f1ce21887ca069330efdd5ccd4ca/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.15677,
         "f1": 0.00266,
         "hamming": 0.001797,
-        "main_score": 0.001561,
+        "main_score": 0.15677,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-base-plus-400k-ft-ls100h/d78e7a1b50e9f1ce21887ca069330efdd5ccd4ca/FSD2019Kaggle.json
+++ b/results/asapp__sew-d-base-plus-400k-ft-ls100h/d78e7a1b50e9f1ce21887ca069330efdd5ccd4ca/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.149305,
         "f1": 0.001314,
         "hamming": 0.000908,
-        "main_score": 0.000781,
+        "main_score": 0.149305,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.096062,
         "f1": 0.000327,
         "hamming": 0.000219,
-        "main_score": 0.000201,
+        "main_score": 0.096062,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-base-plus-400k-ft-ls100h/d78e7a1b50e9f1ce21887ca069330efdd5ccd4ca/FSD50K.json
+++ b/results/asapp__sew-d-base-plus-400k-ft-ls100h/d78e7a1b50e9f1ce21887ca069330efdd5ccd4ca/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.205759
           }
         ],
-        "main_score": 0.000717,
+        "main_score": 0.204133,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-mid-400k-ft-ls100h/b2ff9fdb3bddc81657cf5f16bc0c510be0a39b3e/BirdSet.json
+++ b/results/asapp__sew-d-mid-400k-ft-ls100h/b2ff9fdb3bddc81657cf5f16bc0c510be0a39b3e/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.165349,
         "f1": 0.002827,
         "hamming": 0.002268,
-        "main_score": 0.002,
+        "main_score": 0.165349,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-mid-400k-ft-ls100h/b2ff9fdb3bddc81657cf5f16bc0c510be0a39b3e/FSD2019Kaggle.json
+++ b/results/asapp__sew-d-mid-400k-ft-ls100h/b2ff9fdb3bddc81657cf5f16bc0c510be0a39b3e/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.185782,
         "f1": 0.003568,
         "hamming": 0.002046,
-        "main_score": 0.001696,
+        "main_score": 0.185782,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.108243,
         "f1": 0.00116,
         "hamming": 0.000768,
-        "main_score": 0.000625,
+        "main_score": 0.108243,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-mid-400k-ft-ls100h/b2ff9fdb3bddc81657cf5f16bc0c510be0a39b3e/FSD50K.json
+++ b/results/asapp__sew-d-mid-400k-ft-ls100h/b2ff9fdb3bddc81657cf5f16bc0c510be0a39b3e/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.220776
           }
         ],
-        "main_score": 0.000563,
+        "main_score": 0.216181,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-tiny-100k-ft-ls100h/1966cdcfbd2123ee90b003c2aa6ec6fe204cc4d8/BirdSet.json
+++ b/results/asapp__sew-d-tiny-100k-ft-ls100h/1966cdcfbd2123ee90b003c2aa6ec6fe204cc4d8/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.197816,
         "f1": 0.011106,
         "hamming": 0.012085,
-        "main_score": 0.009512,
+        "main_score": 0.197816,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-tiny-100k-ft-ls100h/1966cdcfbd2123ee90b003c2aa6ec6fe204cc4d8/FSD2019Kaggle.json
+++ b/results/asapp__sew-d-tiny-100k-ft-ls100h/1966cdcfbd2123ee90b003c2aa6ec6fe204cc4d8/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.231705,
         "f1": 0.013935,
         "hamming": 0.008624,
-        "main_score": 0.006896,
+        "main_score": 0.231705,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.126877,
         "f1": 0.007214,
         "hamming": 0.004427,
-        "main_score": 0.003147,
+        "main_score": 0.126877,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/asapp__sew-d-tiny-100k-ft-ls100h/1966cdcfbd2123ee90b003c2aa6ec6fe204cc4d8/FSD50K.json
+++ b/results/asapp__sew-d-tiny-100k-ft-ls100h/1966cdcfbd2123ee90b003c2aa6ec6fe204cc4d8/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.269782
           }
         ],
-        "main_score": 0.002816,
+        "main_score": 0.267378,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__data2vec-audio-base-960h/32331f3123e703528918aa688a9a38232d58c872/BirdSet.json
+++ b/results/facebook__data2vec-audio-base-960h/32331f3123e703528918aa688a9a38232d58c872/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.168615,
         "f1": 0.002936,
         "hamming": 0.003297,
-        "main_score": 0.002488,
+        "main_score": 0.168615,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__data2vec-audio-base-960h/32331f3123e703528918aa688a9a38232d58c872/FSD2019Kaggle.json
+++ b/results/facebook__data2vec-audio-base-960h/32331f3123e703528918aa688a9a38232d58c872/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.210911,
         "f1": 0.012538,
         "hamming": 0.007255,
-        "main_score": 0.00549,
+        "main_score": 0.210911,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.1169,
         "f1": 0.003859,
         "hamming": 0.003183,
-        "main_score": 0.00212,
+        "main_score": 0.1169,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__data2vec-audio-base-960h/32331f3123e703528918aa688a9a38232d58c872/FSD50K.json
+++ b/results/facebook__data2vec-audio-base-960h/32331f3123e703528918aa688a9a38232d58c872/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.27894
           }
         ],
-        "main_score": 0.004403,
+        "main_score": 0.274833,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__data2vec-audio-large-960h/27aba26eed532b86dcd0f17284a0307de4b51f39/BirdSet.json
+++ b/results/facebook__data2vec-audio-large-960h/27aba26eed532b86dcd0f17284a0307de4b51f39/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.329038,
         "f1": 0.0108,
         "hamming": 0.06874,
-        "main_score": 0.060341,
+        "main_score": 0.329038,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__data2vec-audio-large-960h/27aba26eed532b86dcd0f17284a0307de4b51f39/FSD2019Kaggle.json
+++ b/results/facebook__data2vec-audio-large-960h/27aba26eed532b86dcd0f17284a0307de4b51f39/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.222502,
         "f1": 0.015945,
         "hamming": 0.010826,
-        "main_score": 0.008592,
+        "main_score": 0.222502,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.122047,
         "f1": 0.00279,
         "hamming": 0.002217,
-        "main_score": 0.001852,
+        "main_score": 0.122047,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__data2vec-audio-large-960h/27aba26eed532b86dcd0f17284a0307de4b51f39/FSD50K.json
+++ b/results/facebook__data2vec-audio-large-960h/27aba26eed532b86dcd0f17284a0307de4b51f39/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.275281
           }
         ],
-        "main_score": 0.003994,
+        "main_score": 0.275179,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__encodec_24khz/c1dbe2ae3f1de713481a3b3e7c47f357092ee040/BirdSet.json
+++ b/results/facebook__encodec_24khz/c1dbe2ae3f1de713481a3b3e7c47f357092ee040/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.276015,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.276015,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__encodec_24khz/c1dbe2ae3f1de713481a3b3e7c47f357092ee040/FSD2019Kaggle.json
+++ b/results/facebook__encodec_24khz/c1dbe2ae3f1de713481a3b3e7c47f357092ee040/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.080195,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.080195,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.074133,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.074133,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__encodec_24khz/c1dbe2ae3f1de713481a3b3e7c47f357092ee040/FSD50K.json
+++ b/results/facebook__encodec_24khz/c1dbe2ae3f1de713481a3b3e7c47f357092ee040/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.207545
           }
         ],
-        "main_score": 0.0,
+        "main_score": 0.20754,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__hubert-base-ls960/dba3bb02fda4248b6e082697eee756de8fe8aa8a/BirdSet.json
+++ b/results/facebook__hubert-base-ls960/dba3bb02fda4248b6e082697eee756de8fe8aa8a/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.245337,
         "f1": 0.028298,
         "hamming": 0.067254,
-        "main_score": 0.050341,
+        "main_score": 0.245337,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__hubert-base-ls960/dba3bb02fda4248b6e082697eee756de8fe8aa8a/FSD2019Kaggle.json
+++ b/results/facebook__hubert-base-ls960/dba3bb02fda4248b6e082697eee756de8fe8aa8a/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.308237,
         "f1": 0.049469,
         "hamming": 0.030311,
-        "main_score": 0.023365,
+        "main_score": 0.308237,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.153555,
         "f1": 0.016485,
         "hamming": 0.012143,
-        "main_score": 0.008279,
+        "main_score": 0.153555,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__hubert-base-ls960/dba3bb02fda4248b6e082697eee756de8fe8aa8a/FSD50K.json
+++ b/results/facebook__hubert-base-ls960/dba3bb02fda4248b6e082697eee756de8fe8aa8a/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.310108
           }
         ],
-        "main_score": 0.005632,
+        "main_score": 0.308018,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__hubert-large-ls960-ft/ece5fabbf034c1073acae96d5401b25be96709d8/BirdSet.json
+++ b/results/facebook__hubert-large-ls960-ft/ece5fabbf034c1073acae96d5401b25be96709d8/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.221867,
         "f1": 0.004743,
         "hamming": 0.002537,
-        "main_score": 0.002195,
+        "main_score": 0.221867,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__hubert-large-ls960-ft/ece5fabbf034c1073acae96d5401b25be96709d8/FSD2019Kaggle.json
+++ b/results/facebook__hubert-large-ls960-ft/ece5fabbf034c1073acae96d5401b25be96709d8/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.315233,
         "f1": 0.015939,
         "hamming": 0.010461,
-        "main_score": 0.008436,
+        "main_score": 0.315233,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.151807,
         "f1": 0.002131,
         "hamming": 0.001356,
-        "main_score": 0.001227,
+        "main_score": 0.151807,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__hubert-large-ls960-ft/ece5fabbf034c1073acae96d5401b25be96709d8/FSD50K.json
+++ b/results/facebook__hubert-large-ls960-ft/ece5fabbf034c1073acae96d5401b25be96709d8/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.3123
           }
         ],
-        "main_score": 0.003687,
+        "main_score": 0.30839,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-all/3d33597edbdaaba14a8e858e2c8caa76e3cec0cd/BirdSet.json
+++ b/results/facebook__mms-1b-all/3d33597edbdaaba14a8e858e2c8caa76e3cec0cd/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.256484,
         "f1": 0.032007,
         "hamming": 0.019199,
-        "main_score": 0.015854,
+        "main_score": 0.256484,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-all/3d33597edbdaaba14a8e858e2c8caa76e3cec0cd/FSD2019Kaggle.json
+++ b/results/facebook__mms-1b-all/3d33597edbdaaba14a8e858e2c8caa76e3cec0cd/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.310338,
         "f1": 0.095884,
         "hamming": 0.062915,
-        "main_score": 0.048204,
+        "main_score": 0.310338,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.143365,
         "f1": 0.031192,
         "hamming": 0.023945,
-        "main_score": 0.01185,
+        "main_score": 0.143365,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-all/3d33597edbdaaba14a8e858e2c8caa76e3cec0cd/FSD50K.json
+++ b/results/facebook__mms-1b-all/3d33597edbdaaba14a8e858e2c8caa76e3cec0cd/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.326984
           }
         ],
-        "main_score": 0.011623,
+        "main_score": 0.335275,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-fl102/d483345545bea550895b1aa0c6ba40236b9f1e22/BirdSet.json
+++ b/results/facebook__mms-1b-fl102/d483345545bea550895b1aa0c6ba40236b9f1e22/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.235624,
         "f1": 0.023159,
         "hamming": 0.046407,
-        "main_score": 0.034293,
+        "main_score": 0.235624,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-fl102/d483345545bea550895b1aa0c6ba40236b9f1e22/FSD2019Kaggle.json
+++ b/results/facebook__mms-1b-fl102/d483345545bea550895b1aa0c6ba40236b9f1e22/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.336803,
         "f1": 0.121751,
         "hamming": 0.079583,
-        "main_score": 0.061437,
+        "main_score": 0.336803,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.143594,
         "f1": 0.032201,
         "hamming": 0.025469,
-        "main_score": 0.012832,
+        "main_score": 0.143594,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-fl102/d483345545bea550895b1aa0c6ba40236b9f1e22/FSD50K.json
+++ b/results/facebook__mms-1b-fl102/d483345545bea550895b1aa0c6ba40236b9f1e22/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.33421
           }
         ],
-        "main_score": 0.01234,
+        "main_score": 0.331588,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-l1107/1fdc004dff8c399df6b15f136abfe8e83e073d51/BirdSet.json
+++ b/results/facebook__mms-1b-l1107/1fdc004dff8c399df6b15f136abfe8e83e073d51/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.249258,
         "f1": 0.009749,
         "hamming": 0.003715,
-        "main_score": 0.003512,
+        "main_score": 0.249258,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-l1107/1fdc004dff8c399df6b15f136abfe8e83e073d51/FSD2019Kaggle.json
+++ b/results/facebook__mms-1b-l1107/1fdc004dff8c399df6b15f136abfe8e83e073d51/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.347033,
         "f1": 0.041975,
         "hamming": 0.027812,
-        "main_score": 0.024459,
+        "main_score": 0.347033,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.152866,
         "f1": 0.013469,
         "hamming": 0.007787,
-        "main_score": 0.004664,
+        "main_score": 0.152866,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__mms-1b-l1107/1fdc004dff8c399df6b15f136abfe8e83e073d51/FSD50K.json
+++ b/results/facebook__mms-1b-l1107/1fdc004dff8c399df6b15f136abfe8e83e073d51/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.33585
           }
         ],
-        "main_score": 0.005018,
+        "main_score": 0.333891,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__seamless-m4t-v2-large/5f8cc790b19fc3f67a61c105133b20b34e3dcb76/BirdSet.json
+++ b/results/facebook__seamless-m4t-v2-large/5f8cc790b19fc3f67a61c105133b20b34e3dcb76/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.286924,
         "f1": 0.00181,
         "hamming": 0.000293,
-        "main_score": 0.000293,
+        "main_score": 0.286924,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__seamless-m4t-v2-large/5f8cc790b19fc3f67a61c105133b20b34e3dcb76/FSD2019Kaggle.json
+++ b/results/facebook__seamless-m4t-v2-large/5f8cc790b19fc3f67a61c105133b20b34e3dcb76/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.287953,
         "f1": 0.03479,
         "hamming": 0.019469,
-        "main_score": 0.015041,
+        "main_score": 0.287953,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.162719,
         "f1": 0.011111,
         "hamming": 0.00763,
-        "main_score": 0.005579,
+        "main_score": 0.162719,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__seamless-m4t-v2-large/5f8cc790b19fc3f67a61c105133b20b34e3dcb76/FSD50K.json
+++ b/results/facebook__seamless-m4t-v2-large/5f8cc790b19fc3f67a61c105133b20b34e3dcb76/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.342165
           }
         ],
-        "main_score": 0.009114,
+        "main_score": 0.344264,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-base-960h/22aad52d435eb6dbaf354bdad9b0da84ce7d6156/BirdSet.json
+++ b/results/facebook__wav2vec2-base-960h/22aad52d435eb6dbaf354bdad9b0da84ce7d6156/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.184669,
         "f1": 0.001135,
         "hamming": 0.000683,
-        "main_score": 0.000585,
+        "main_score": 0.184669,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-base-960h/22aad52d435eb6dbaf354bdad9b0da84ce7d6156/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-base-960h/22aad52d435eb6dbaf354bdad9b0da84ce7d6156/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.150137
           }
         ],
-        "main_score": 0.000714,
+        "main_score": 0.154295,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.090251
           }
         ],
-        "main_score": 4.5e-05,
+        "main_score": 0.093316,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-base-960h/22aad52d435eb6dbaf354bdad9b0da84ce7d6156/FSD50K.json
+++ b/results/facebook__wav2vec2-base-960h/22aad52d435eb6dbaf354bdad9b0da84ce7d6156/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.819987,
         "f1": 0.308914,
         "hamming": 0.579998,
-        "main_score": 0.0,
+        "main_score": 0.819987,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-base/0b5b8e868dd84f03fd87d01f9c4ff0f080fecfe8/BirdSet.json
+++ b/results/facebook__wav2vec2-base/0b5b8e868dd84f03fd87d01f9c4ff0f080fecfe8/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.170142,
         "f1": 0.008149,
         "hamming": 0.007325,
-        "main_score": 0.005902,
+        "main_score": 0.170142,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-base/0b5b8e868dd84f03fd87d01f9c4ff0f080fecfe8/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-base/0b5b8e868dd84f03fd87d01f9c4ff0f080fecfe8/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.252687
           }
         ],
-        "main_score": 0.018902,
+        "main_score": 0.249958,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.11754
           }
         ],
-        "main_score": 0.004039,
+        "main_score": 0.117987,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-base/0b5b8e868dd84f03fd87d01f9c4ff0f080fecfe8/FSD50K.json
+++ b/results/facebook__wav2vec2-base/0b5b8e868dd84f03fd87d01f9c4ff0f080fecfe8/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.802616,
         "f1": 0.364762,
         "hamming": 0.555049,
-        "main_score": 0.000684,
+        "main_score": 0.802616,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-large-xlsr-53/c3f9d884181a224a6ac87bf8885c84d1cff3384f/BirdSet.json
+++ b/results/facebook__wav2vec2-large-xlsr-53/c3f9d884181a224a6ac87bf8885c84d1cff3384f/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.204781,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.204781,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-large-xlsr-53/c3f9d884181a224a6ac87bf8885c84d1cff3384f/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-large-xlsr-53/c3f9d884181a224a6ac87bf8885c84d1cff3384f/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.082294
           }
         ],
-        "main_score": 0.0,
+        "main_score": 0.078681,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.066545
           }
         ],
-        "main_score": 0.0,
+        "main_score": 0.070849,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-large-xlsr-53/c3f9d884181a224a6ac87bf8885c84d1cff3384f/FSD50K.json
+++ b/results/facebook__wav2vec2-large-xlsr-53/c3f9d884181a224a6ac87bf8885c84d1cff3384f/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.831765,
         "f1": 0.285287,
         "hamming": 0.593412,
-        "main_score": 0.0,
+        "main_score": 0.831765,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-large/312b2410566b698c7a649068d413b2067848bd75/BirdSet.json
+++ b/results/facebook__wav2vec2-large/312b2410566b698c7a649068d413b2067848bd75/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.164903,
         "f1": 9.5e-05,
         "hamming": 0.000171,
-        "main_score": 0.000146,
+        "main_score": 0.164903,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-large/312b2410566b698c7a649068d413b2067848bd75/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-large/312b2410566b698c7a649068d413b2067848bd75/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.154584
           }
         ],
-        "main_score": 0.002477,
+        "main_score": 0.15816,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.091996
           }
         ],
-        "main_score": 0.001227,
+        "main_score": 0.09319,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-large/312b2410566b698c7a649068d413b2067848bd75/FSD50K.json
+++ b/results/facebook__wav2vec2-large/312b2410566b698c7a649068d413b2067848bd75/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.819228,
         "f1": 0.321276,
         "hamming": 0.580343,
-        "main_score": 4.9e-05,
+        "main_score": 0.819228,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-lv-60-espeak-cv-ft/ae45363bf3413b374fecd9dc8bc1df0e24c3b7f4/BirdSet.json
+++ b/results/facebook__wav2vec2-lv-60-espeak-cv-ft/ae45363bf3413b374fecd9dc8bc1df0e24c3b7f4/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.145142,
         "f1": 0.009683,
         "hamming": 0.002569,
-        "main_score": 0.002098,
+        "main_score": 0.145142,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-lv-60-espeak-cv-ft/ae45363bf3413b374fecd9dc8bc1df0e24c3b7f4/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-lv-60-espeak-cv-ft/ae45363bf3413b374fecd9dc8bc1df0e24c3b7f4/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.35031,
         "f1": 0.071453,
         "hamming": 0.047218,
-        "main_score": 0.039054,
+        "main_score": 0.35031,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.156173,
         "f1": 0.015996,
         "hamming": 0.011283,
-        "main_score": 0.00819,
+        "main_score": 0.156173,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-lv-60-espeak-cv-ft/ae45363bf3413b374fecd9dc8bc1df0e24c3b7f4/FSD50K.json
+++ b/results/facebook__wav2vec2-lv-60-espeak-cv-ft/ae45363bf3413b374fecd9dc8bc1df0e24c3b7f4/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.810844,
         "f1": 0.391265,
         "hamming": 0.564209,
-        "main_score": 0.001416,
+        "main_score": 0.810844,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-1b/35eaea9a0ed0f97592277d79208e40ab8917d1e3/BirdSet.json
+++ b/results/facebook__wav2vec2-xls-r-1b/35eaea9a0ed0f97592277d79208e40ab8917d1e3/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.244977,
         "f1": 0.007827,
         "hamming": 0.006951,
-        "main_score": 0.006244,
+        "main_score": 0.244977,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-1b/35eaea9a0ed0f97592277d79208e40ab8917d1e3/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-xls-r-1b/35eaea9a0ed0f97592277d79208e40ab8917d1e3/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.361025
           }
         ],
-        "main_score": 0.027672,
+        "main_score": 0.366448,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.156369
           }
         ],
-        "main_score": 0.005646,
+        "main_score": 0.158669,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-1b/35eaea9a0ed0f97592277d79208e40ab8917d1e3/FSD50K.json
+++ b/results/facebook__wav2vec2-xls-r-1b/35eaea9a0ed0f97592277d79208e40ab8917d1e3/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.820619,
         "f1": 0.38016,
         "hamming": 0.578125,
-        "main_score": 0.000928,
+        "main_score": 0.820619,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-2b-21-to-en/70239d15f5b39ecbc936a5e214bf401b7f17e210/BirdSet.json
+++ b/results/facebook__wav2vec2-xls-r-2b-21-to-en/70239d15f5b39ecbc936a5e214bf401b7f17e210/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.0897,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.0897,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-2b-21-to-en/70239d15f5b39ecbc936a5e214bf401b7f17e210/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-xls-r-2b-21-to-en/70239d15f5b39ecbc936a5e214bf401b7f17e210/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.046774,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.046774,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.051446,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.051446,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-2b-21-to-en/70239d15f5b39ecbc936a5e214bf401b7f17e210/FSD50K.json
+++ b/results/facebook__wav2vec2-xls-r-2b-21-to-en/70239d15f5b39ecbc936a5e214bf401b7f17e210/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.827942,
         "f1": 0.283574,
         "hamming": 0.592804,
-        "main_score": 0.0,
+        "main_score": 0.827942,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-2b/3b6d89d0fabead7da552eaaa07549c7c9c36d303/BirdSet.json
+++ b/results/facebook__wav2vec2-xls-r-2b/3b6d89d0fabead7da552eaaa07549c7c9c36d303/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.258074,
         "f1": 0.005757,
         "hamming": 0.004748,
-        "main_score": 0.004293,
+        "main_score": 0.258074,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-2b/3b6d89d0fabead7da552eaaa07549c7c9c36d303/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-xls-r-2b/3b6d89d0fabead7da552eaaa07549c7c9c36d303/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.429319
           }
         ],
-        "main_score": 0.040594,
+        "main_score": 0.427766,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.191504
           }
         ],
-        "main_score": 0.009194,
+        "main_score": 0.194789,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-2b/3b6d89d0fabead7da552eaaa07549c7c9c36d303/FSD50K.json
+++ b/results/facebook__wav2vec2-xls-r-2b/3b6d89d0fabead7da552eaaa07549c7c9c36d303/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.82159,
         "f1": 0.396734,
         "hamming": 0.57686,
-        "main_score": 0.001221,
+        "main_score": 0.82159,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-300m/1a640f32ac3e39899438a2931f9924c02f080a54/BirdSet.json
+++ b/results/facebook__wav2vec2-xls-r-300m/1a640f32ac3e39899438a2931f9924c02f080a54/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.242359,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.242359,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-300m/1a640f32ac3e39899438a2931f9924c02f080a54/FSD2019Kaggle.json
+++ b/results/facebook__wav2vec2-xls-r-300m/1a640f32ac3e39899438a2931f9924c02f080a54/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.259309,
         "f1": 0.00029,
         "hamming": 0.000223,
-        "main_score": 0.000179,
+        "main_score": 0.259309,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.121565,
         "f1": 0.000297,
         "hamming": 0.000182,
-        "main_score": 0.000134,
+        "main_score": 0.121565,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/facebook__wav2vec2-xls-r-300m/1a640f32ac3e39899438a2931f9924c02f080a54/FSD50K.json
+++ b/results/facebook__wav2vec2-xls-r-300m/1a640f32ac3e39899438a2931f9924c02f080a54/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.836682,
         "f1": 0.306049,
         "hamming": 0.598781,
-        "main_score": 0.0,
+        "main_score": 0.836682,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/google__vggish/1/BirdSet.json
+++ b/results/google__vggish/1/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.215445,
         "f1": 2.5e-05,
         "hamming": 2.4e-05,
-        "main_score": 0.0,
+        "main_score": 0.215445,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/google__vggish/1/FSD2019Kaggle.json
+++ b/results/google__vggish/1/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.470438,
         "f1": 0.121179,
         "hamming": 0.066879,
-        "main_score": 0.042468,
+        "main_score": 0.470438,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.297065,
         "f1": 0.072275,
         "hamming": 0.040952,
-        "main_score": 0.027315,
+        "main_score": 0.297065,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/google__vggish/1/FSD50K.json
+++ b/results/google__vggish/1/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.841755,
         "f1": 0.408908,
         "hamming": 0.601852,
-        "main_score": 0.004688,
+        "main_score": 0.841755,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/google__yamnet/1/BirdSet.json
+++ b/results/google__yamnet/1/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.218895,
         "f1": 0.015882,
         "hamming": 0.038614,
-        "main_score": 0.025073,
+        "main_score": 0.218895,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/google__yamnet/1/FSD2019Kaggle.json
+++ b/results/google__yamnet/1/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.573766,
         "f1": 0.3434,
         "hamming": 0.250057,
-        "main_score": 0.189489,
+        "main_score": 0.573766,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.411509,
         "f1": 0.244767,
         "hamming": 0.176401,
-        "main_score": 0.092814,
+        "main_score": 0.411509,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/google__yamnet/1/FSD50K.json
+++ b/results/google__yamnet/1/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.825235,
         "f1": 0.478756,
         "hamming": 0.589519,
-        "main_score": 0.013379,
+        "main_score": 0.825235,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__clap-htsat-fused/cca9e288ab447cee67d9ada1f85ddb46500f1401/BirdSet.json
+++ b/results/laion__clap-htsat-fused/cca9e288ab447cee67d9ada1f85ddb46500f1401/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.197141,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.197141,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__clap-htsat-fused/cca9e288ab447cee67d9ada1f85ddb46500f1401/FSD2019Kaggle.json
+++ b/results/laion__clap-htsat-fused/cca9e288ab447cee67d9ada1f85ddb46500f1401/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.810872,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.810872,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.403698,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.403698,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/laion__clap-htsat-fused/cca9e288ab447cee67d9ada1f85ddb46500f1401/FSD50K.json
+++ b/results/laion__clap-htsat-fused/cca9e288ab447cee67d9ada1f85ddb46500f1401/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.631709
           }
         ],
-        "main_score": 0.007629,
+        "main_score": 0.631633,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__clap-htsat-unfused/8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a/BirdSet.json
+++ b/results/laion__clap-htsat-unfused/8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.178218,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.178218,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__clap-htsat-unfused/8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a/FSD2019Kaggle.json
+++ b/results/laion__clap-htsat-unfused/8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.808447,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.808447,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.457003,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.457003,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/laion__clap-htsat-unfused/8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a/FSD50K.json
+++ b/results/laion__clap-htsat-unfused/8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.676989
           }
         ],
-        "main_score": 0.010343,
+        "main_score": 0.67796,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_general/ada0c23a36c4e8582805bb38fec3905903f18b41/BirdSet.json
+++ b/results/laion__larger_clap_general/ada0c23a36c4e8582805bb38fec3905903f18b41/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.198476,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.198476,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_general/ada0c23a36c4e8582805bb38fec3905903f18b41/FSD2019Kaggle.json
+++ b/results/laion__larger_clap_general/ada0c23a36c4e8582805bb38fec3905903f18b41/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.806314,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.806314,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.476242,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.476242,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_general/ada0c23a36c4e8582805bb38fec3905903f18b41/FSD50K.json
+++ b/results/laion__larger_clap_general/ada0c23a36c4e8582805bb38fec3905903f18b41/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.653164
           }
         ],
-        "main_score": 0.007271,
+        "main_score": 0.653809,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_music/a0b4534a14f58e20944452dff00a22a06ce629d1/BirdSet.json
+++ b/results/laion__larger_clap_music/a0b4534a14f58e20944452dff00a22a06ce629d1/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.122629,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.122629,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_music/a0b4534a14f58e20944452dff00a22a06ce629d1/FSD2019Kaggle.json
+++ b/results/laion__larger_clap_music/a0b4534a14f58e20944452dff00a22a06ce629d1/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.080966,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.080966,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.07638,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.07638,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_music/a0b4534a14f58e20944452dff00a22a06ce629d1/FSD50K.json
+++ b/results/laion__larger_clap_music/a0b4534a14f58e20944452dff00a22a06ce629d1/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.200985
           }
         ],
-        "main_score": 0.0,
+        "main_score": 0.201124,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_music_and_speech/195c3a3e68faebb3e2088b9a79e79b43ddbda76b/BirdSet.json
+++ b/results/laion__larger_clap_music_and_speech/195c3a3e68faebb3e2088b9a79e79b43ddbda76b/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.152886,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.152886,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_music_and_speech/195c3a3e68faebb3e2088b9a79e79b43ddbda76b/FSD2019Kaggle.json
+++ b/results/laion__larger_clap_music_and_speech/195c3a3e68faebb3e2088b9a79e79b43ddbda76b/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.806193,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.806193,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.444969,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.444969,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/laion__larger_clap_music_and_speech/195c3a3e68faebb3e2088b9a79e79b43ddbda76b/FSD50K.json
+++ b/results/laion__larger_clap_music_and_speech/195c3a3e68faebb3e2088b9a79e79b43ddbda76b/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.659186
           }
         ],
-        "main_score": 0.01065,
+        "main_score": 0.661269,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/lyrebird__wav2clip/no_revision/BirdSet.json
+++ b/results/lyrebird__wav2clip/no_revision/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.215864,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.215864,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/lyrebird__wav2clip/no_revision/FSD2019Kaggle.json
+++ b/results/lyrebird__wav2clip/no_revision/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.317888,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.317888,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.198724,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.198724,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/lyrebird__wav2clip/no_revision/FSD50K.json
+++ b/results/lyrebird__wav2clip/no_revision/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.840488,
         "f1": 0.29934,
         "hamming": 0.597368,
-        "main_score": 0.0,
+        "main_score": 0.840488,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__msclap-2022/no_revision/BirdSet.json
+++ b/results/microsoft__msclap-2022/no_revision/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.194948,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.194948,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__msclap-2022/no_revision/FSD2019Kaggle.json
+++ b/results/microsoft__msclap-2022/no_revision/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.708599,
         "f1": 0.000442,
         "hamming": 0.000195,
-        "main_score": 0.000112,
+        "main_score": 0.708599,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.450761,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.450761,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__msclap-2022/no_revision/FSD50K.json
+++ b/results/microsoft__msclap-2022/no_revision/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.859452,
         "f1": 0.345569,
         "hamming": 0.611658,
-        "main_score": 0.000244,
+        "main_score": 0.859452,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__msclap-2023/no_revision/BirdSet.json
+++ b/results/microsoft__msclap-2023/no_revision/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.271039,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.271039,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__msclap-2023/no_revision/FSD2019Kaggle.json
+++ b/results/microsoft__msclap-2023/no_revision/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.797336,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.797336,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.474991,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.474991,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__msclap-2023/no_revision/FSD50K.json
+++ b/results/microsoft__msclap-2023/no_revision/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.860954,
         "f1": 0.319874,
         "hamming": 0.607226,
-        "main_score": 0.0,
+        "main_score": 0.860954,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__speecht5_multimodal/53615c10408485422e09a12cda191a747f4bbe34-30fcde30f19b87502b8435427b5f5068e401d5f6/BirdSet.json
+++ b/results/microsoft__speecht5_multimodal/53615c10408485422e09a12cda191a747f4bbe34-30fcde30f19b87502b8435427b5f5068e401d5f6/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.25562,
         "f1": 0.004171,
         "hamming": 0.003606,
-        "main_score": 0.003122,
+        "main_score": 0.25562,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__speecht5_multimodal/53615c10408485422e09a12cda191a747f4bbe34-30fcde30f19b87502b8435427b5f5068e401d5f6/FSD2019Kaggle.json
+++ b/results/microsoft__speecht5_multimodal/53615c10408485422e09a12cda191a747f4bbe34-30fcde30f19b87502b8435427b5f5068e401d5f6/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.325311,
         "f1": 0.021475,
         "hamming": 0.013174,
-        "main_score": 0.010957,
+        "main_score": 0.325311,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.169035,
         "f1": 0.007666,
         "hamming": 0.005214,
-        "main_score": 0.004151,
+        "main_score": 0.169035,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__speecht5_multimodal/53615c10408485422e09a12cda191a747f4bbe34-30fcde30f19b87502b8435427b5f5068e401d5f6/FSD50K.json
+++ b/results/microsoft__speecht5_multimodal/53615c10408485422e09a12cda191a747f4bbe34-30fcde30f19b87502b8435427b5f5068e401d5f6/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.825284,
         "f1": 0.34527,
         "hamming": 0.583805,
-        "main_score": 9.8e-05,
+        "main_score": 0.825284,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__unispeech-sat-base-100h-libri-ft/b294556d8d77cc539f9d08bef0ddbb0f60985328/BirdSet.json
+++ b/results/microsoft__unispeech-sat-base-100h-libri-ft/b294556d8d77cc539f9d08bef0ddbb0f60985328/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.224267,
         "f1": 0.001605,
         "hamming": 0.000659,
-        "main_score": 0.00039,
+        "main_score": 0.224267,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__unispeech-sat-base-100h-libri-ft/b294556d8d77cc539f9d08bef0ddbb0f60985328/FSD2019Kaggle.json
+++ b/results/microsoft__unispeech-sat-base-100h-libri-ft/b294556d8d77cc539f9d08bef0ddbb0f60985328/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.197419
           }
         ],
-        "main_score": 0.001004,
+        "main_score": 0.206146,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.091221
           }
         ],
-        "main_score": 0.000112,
+        "main_score": 0.099578,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__unispeech-sat-base-100h-libri-ft/b294556d8d77cc539f9d08bef0ddbb0f60985328/FSD50K.json
+++ b/results/microsoft__unispeech-sat-base-100h-libri-ft/b294556d8d77cc539f9d08bef0ddbb0f60985328/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.828077,
         "f1": 0.321583,
         "hamming": 0.589456,
-        "main_score": 0.000244,
+        "main_score": 0.828077,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus-sd/5bd86f0662bd55704109a794c6a1b1790ea0f91a/BirdSet.json
+++ b/results/microsoft__wavlm-base-plus-sd/5bd86f0662bd55704109a794c6a1b1790ea0f91a/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.274198,
         "f1": 0.000947,
         "hamming": 0.00178,
-        "main_score": 0.001561,
+        "main_score": 0.274198,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus-sd/5bd86f0662bd55704109a794c6a1b1790ea0f91a/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-base-plus-sd/5bd86f0662bd55704109a794c6a1b1790ea0f91a/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.225752
           }
         ],
-        "main_score": 0.00462,
+        "main_score": 0.229082,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.111469
           }
         ],
-        "main_score": 0.000803,
+        "main_score": 0.117513,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus-sd/5bd86f0662bd55704109a794c6a1b1790ea0f91a/FSD50K.json
+++ b/results/microsoft__wavlm-base-plus-sd/5bd86f0662bd55704109a794c6a1b1790ea0f91a/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.297116
           }
         ],
-        "main_score": 0.002407,
+        "main_score": 0.295742,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus-sv/feb593a6c23c1cc3d9510425c29b0a14d2b07b1e/BirdSet.json
+++ b/results/microsoft__wavlm-base-plus-sv/feb593a6c23c1cc3d9510425c29b0a14d2b07b1e/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.274198,
         "f1": 0.000947,
         "hamming": 0.00178,
-        "main_score": 0.001561,
+        "main_score": 0.274198,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus-sv/feb593a6c23c1cc3d9510425c29b0a14d2b07b1e/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-base-plus-sv/feb593a6c23c1cc3d9510425c29b0a14d2b07b1e/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.225752
           }
         ],
-        "main_score": 0.00462,
+        "main_score": 0.229082,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.111469
           }
         ],
-        "main_score": 0.000803,
+        "main_score": 0.117513,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus-sv/feb593a6c23c1cc3d9510425c29b0a14d2b07b1e/FSD50K.json
+++ b/results/microsoft__wavlm-base-plus-sv/feb593a6c23c1cc3d9510425c29b0a14d2b07b1e/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.297116
           }
         ],
-        "main_score": 0.002407,
+        "main_score": 0.295742,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus/4c66d4806a428f2e922ccfa1a962776e232d487b/BirdSet.json
+++ b/results/microsoft__wavlm-base-plus/4c66d4806a428f2e922ccfa1a962776e232d487b/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.274198,
         "f1": 0.000947,
         "hamming": 0.00178,
-        "main_score": 0.001561,
+        "main_score": 0.274198,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus/4c66d4806a428f2e922ccfa1a962776e232d487b/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-base-plus/4c66d4806a428f2e922ccfa1a962776e232d487b/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.225752
           }
         ],
-        "main_score": 0.00462,
+        "main_score": 0.229082,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.111469
           }
         ],
-        "main_score": 0.000803,
+        "main_score": 0.117513,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-plus/4c66d4806a428f2e922ccfa1a962776e232d487b/FSD50K.json
+++ b/results/microsoft__wavlm-base-plus/4c66d4806a428f2e922ccfa1a962776e232d487b/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.297116
           }
         ],
-        "main_score": 0.002407,
+        "main_score": 0.295742,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-sd/fe13cca7e592cf0e11287cfede24e6999ac7dc4e/BirdSet.json
+++ b/results/microsoft__wavlm-base-sd/fe13cca7e592cf0e11287cfede24e6999ac7dc4e/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.296219,
         "f1": 0.01345,
         "hamming": 0.032098,
-        "main_score": 0.023366,
+        "main_score": 0.296219,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-sd/fe13cca7e592cf0e11287cfede24e6999ac7dc4e/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-base-sd/fe13cca7e592cf0e11287cfede24e6999ac7dc4e/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.194496
           }
         ],
-        "main_score": 0.010734,
+        "main_score": 0.201766,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.094509
           }
         ],
-        "main_score": 0.003972,
+        "main_score": 0.095155,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-sd/fe13cca7e592cf0e11287cfede24e6999ac7dc4e/FSD50K.json
+++ b/results/microsoft__wavlm-base-sd/fe13cca7e592cf0e11287cfede24e6999ac7dc4e/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.261868
           }
         ],
-        "main_score": 0.005172,
+        "main_score": 0.258863,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-sv/0a23162ffc49adcf42bdf836a00cb2eb45af3601/BirdSet.json
+++ b/results/microsoft__wavlm-base-sv/0a23162ffc49adcf42bdf836a00cb2eb45af3601/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.296219,
         "f1": 0.01345,
         "hamming": 0.032098,
-        "main_score": 0.023366,
+        "main_score": 0.296219,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-sv/0a23162ffc49adcf42bdf836a00cb2eb45af3601/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-base-sv/0a23162ffc49adcf42bdf836a00cb2eb45af3601/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.194496
           }
         ],
-        "main_score": 0.010734,
+        "main_score": 0.201766,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.094509
           }
         ],
-        "main_score": 0.003972,
+        "main_score": 0.095155,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base-sv/0a23162ffc49adcf42bdf836a00cb2eb45af3601/FSD50K.json
+++ b/results/microsoft__wavlm-base-sv/0a23162ffc49adcf42bdf836a00cb2eb45af3601/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.261868
           }
         ],
-        "main_score": 0.005172,
+        "main_score": 0.258863,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base/efa81aae7ff777e464159e0f877d54eac5b84f81/BirdSet.json
+++ b/results/microsoft__wavlm-base/efa81aae7ff777e464159e0f877d54eac5b84f81/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.296219,
         "f1": 0.01345,
         "hamming": 0.032098,
-        "main_score": 0.023366,
+        "main_score": 0.296219,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base/efa81aae7ff777e464159e0f877d54eac5b84f81/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-base/efa81aae7ff777e464159e0f877d54eac5b84f81/FSD2019Kaggle.json
@@ -60,7 +60,7 @@
             "lrap": 0.194496
           }
         ],
-        "main_score": 0.010734,
+        "main_score": 0.201766,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -122,7 +122,7 @@
             "lrap": 0.094509
           }
         ],
-        "main_score": 0.003972,
+        "main_score": 0.095155,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-base/efa81aae7ff777e464159e0f877d54eac5b84f81/FSD50K.json
+++ b/results/microsoft__wavlm-base/efa81aae7ff777e464159e0f877d54eac5b84f81/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.261868
           }
         ],
-        "main_score": 0.005172,
+        "main_score": 0.258863,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-large/c1423ed94bb01d80a3f5ce5bc39f6026a0f4828c/BirdSet.json
+++ b/results/microsoft__wavlm-large/c1423ed94bb01d80a3f5ce5bc39f6026a0f4828c/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.222014,
         "f1": 0.001427,
         "hamming": 0.001512,
-        "main_score": 0.001463,
+        "main_score": 0.222014,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-large/c1423ed94bb01d80a3f5ce5bc39f6026a0f4828c/FSD2019Kaggle.json
+++ b/results/microsoft__wavlm-large/c1423ed94bb01d80a3f5ce5bc39f6026a0f4828c/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.406797,
         "f1": 0.04689,
         "hamming": 0.030317,
-        "main_score": 0.025508,
+        "main_score": 0.406797,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.190561,
         "f1": 0.009614,
         "hamming": 0.006226,
-        "main_score": 0.004709,
+        "main_score": 0.190561,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/microsoft__wavlm-large/c1423ed94bb01d80a3f5ce5bc39f6026a0f4828c/FSD50K.json
+++ b/results/microsoft__wavlm-large/c1423ed94bb01d80a3f5ce5bc39f6026a0f4828c/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.359178
           }
         ],
-        "main_score": 0.00594,
+        "main_score": 0.356777,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-base/main/BirdSet.json
+++ b/results/openai__whisper-base/main/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.257732,
         "f1": 0.016532,
         "hamming": 0.04355,
-        "main_score": 0.038311,
+        "main_score": 0.257732,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-base/main/FSD2019Kaggle.json
+++ b/results/openai__whisper-base/main/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.462637,
         "f1": 0.201901,
         "hamming": 0.133146,
-        "main_score": 0.099487,
+        "main_score": 0.462637,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.219042,
         "f1": 0.090766,
         "hamming": 0.061995,
-        "main_score": 0.025106,
+        "main_score": 0.219042,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-base/main/FSD50K.json
+++ b/results/openai__whisper-base/main/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.444687
           }
         ],
-        "main_score": 0.015463,
+        "main_score": 0.443911,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-large-v3/main/BirdSet.json
+++ b/results/openai__whisper-large-v3/main/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.245586,
         "f1": 0.011623,
         "hamming": 0.06565,
-        "main_score": 0.054954,
+        "main_score": 0.245586,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-large-v3/main/FSD2019Kaggle.json
+++ b/results/openai__whisper-large-v3/main/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.475849,
         "f1": 0.166959,
         "hamming": 0.112885,
-        "main_score": 0.091676,
+        "main_score": 0.475849,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.23423,
         "f1": 0.081583,
         "hamming": 0.052959,
-        "main_score": 0.023722,
+        "main_score": 0.23423,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-large-v3/main/FSD50K.json
+++ b/results/openai__whisper-large-v3/main/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.442734
           }
         ],
-        "main_score": 0.012186,
+        "main_score": 0.442462,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-medium/main/BirdSet.json
+++ b/results/openai__whisper-medium/main/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.194749,
         "f1": 0.013118,
         "hamming": 0.033712,
-        "main_score": 0.027672,
+        "main_score": 0.194749,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-medium/main/FSD2019Kaggle.json
+++ b/results/openai__whisper-medium/main/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.567577,
         "f1": 0.303697,
         "hamming": 0.222004,
-        "main_score": 0.178375,
+        "main_score": 0.567577,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.292271,
         "f1": 0.13989,
         "hamming": 0.098543,
-        "main_score": 0.040705,
+        "main_score": 0.292271,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-medium/main/FSD50K.json
+++ b/results/openai__whisper-medium/main/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.538682
           }
         ],
-        "main_score": 0.032463,
+        "main_score": 0.535392,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-small/main/BirdSet.json
+++ b/results/openai__whisper-small/main/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.258074,
         "f1": 0.021943,
         "hamming": 0.066744,
-        "main_score": 0.05349,
+        "main_score": 0.258074,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-small/main/FSD2019Kaggle.json
+++ b/results/openai__whisper-small/main/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.513812,
         "f1": 0.256879,
         "hamming": 0.179593,
-        "main_score": 0.140348,
+        "main_score": 0.513812,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.25124,
         "f1": 0.117423,
         "hamming": 0.079482,
-        "main_score": 0.025664,
+        "main_score": 0.25124,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-small/main/FSD50K.json
+++ b/results/openai__whisper-small/main/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.496785
           }
         ],
-        "main_score": 0.019406,
+        "main_score": 0.490298,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-tiny/main/BirdSet.json
+++ b/results/openai__whisper-tiny/main/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.300907,
         "f1": 0.016711,
         "hamming": 0.051061,
-        "main_score": 0.042362,
+        "main_score": 0.300907,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-tiny/main/FSD2019Kaggle.json
+++ b/results/openai__whisper-tiny/main/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.413679,
         "f1": 0.151259,
         "hamming": 0.099136,
-        "main_score": 0.075273,
+        "main_score": 0.413679,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.199198,
         "f1": 0.070221,
         "hamming": 0.047521,
-        "main_score": 0.021335,
+        "main_score": 0.199198,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/openai__whisper-tiny/main/FSD50K.json
+++ b/results/openai__whisper-tiny/main/FSD50K.json
@@ -60,7 +60,7 @@
             "lrap": 0.406197
           }
         ],
-        "main_score": 0.012494,
+        "main_score": 0.409759,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/speechbrain__cnn14-esc50/422a112e9a22a5fac0d37571aacaee5caf154395/BirdSet.json
+++ b/results/speechbrain__cnn14-esc50/422a112e9a22a5fac0d37571aacaee5caf154395/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.244849,
         "f1": 0.0,
         "hamming": 0.0,
-        "main_score": 0.0,
+        "main_score": 0.244849,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/speechbrain__cnn14-esc50/422a112e9a22a5fac0d37571aacaee5caf154395/FSD2019Kaggle.json
+++ b/results/speechbrain__cnn14-esc50/422a112e9a22a5fac0d37571aacaee5caf154395/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.277021,
         "f1": 0.000729,
         "hamming": 0.00045,
-        "main_score": 0.000357,
+        "main_score": 0.277021,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.147872,
         "f1": 8.6e-05,
         "hamming": 3.3e-05,
-        "main_score": 0.0,
+        "main_score": 0.147872,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/speechbrain__cnn14-esc50/422a112e9a22a5fac0d37571aacaee5caf154395/FSD50K.json
+++ b/results/speechbrain__cnn14-esc50/422a112e9a22a5fac0d37571aacaee5caf154395/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.837394,
         "f1": 0.290715,
         "hamming": 0.595176,
-        "main_score": 4.9e-05,
+        "main_score": 0.837394,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/speechbrain__m-ctc-t-large/ed014c8255cea2c36f87a71cf2533b665ba00863/FSD2019Kaggle.json
+++ b/results/speechbrain__m-ctc-t-large/ed014c8255cea2c36f87a71cf2533b665ba00863/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.188187,
         "f1": 0.049895,
         "hamming": 0.028048,
-        "main_score": 0.016871,
+        "main_score": 0.188187,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.107193,
         "f1": 0.022156,
         "hamming": 0.013009,
-        "main_score": 0.005356,
+        "main_score": 0.107193,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/speechbrain__m-ctc-t-large/ed014c8255cea2c36f87a71cf2533b665ba00863/FSD50K.json
+++ b/results/speechbrain__m-ctc-t-large/ed014c8255cea2c36f87a71cf2533b665ba00863/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.777855,
         "f1": 0.381404,
         "hamming": 0.524266,
-        "main_score": 0.000439,
+        "main_score": 0.777855,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/vitouphy__wav2vec2-xls-r-300m-phoneme/bf9913bf096d133cf4eca64ed75981ebf0545c9d/BirdSet.json
+++ b/results/vitouphy__wav2vec2-xls-r-300m-phoneme/bf9913bf096d133cf4eca64ed75981ebf0545c9d/BirdSet.json
@@ -71,7 +71,7 @@
         "lrap": 0.261657,
         "f1": 0.004914,
         "hamming": 0.002927,
-        "main_score": 0.002683,
+        "main_score": 0.261657,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"

--- a/results/vitouphy__wav2vec2-xls-r-300m-phoneme/bf9913bf096d133cf4eca64ed75981ebf0545c9d/FSD2019Kaggle.json
+++ b/results/vitouphy__wav2vec2-xls-r-300m-phoneme/bf9913bf096d133cf4eca64ed75981ebf0545c9d/FSD2019Kaggle.json
@@ -71,7 +71,7 @@
         "lrap": 0.361828,
         "f1": 0.012541,
         "hamming": 0.008757,
-        "main_score": 0.00674,
+        "main_score": 0.361828,
         "hf_subset": "curated",
         "languages": [
           "eng-Latn"
@@ -144,7 +144,7 @@
         "lrap": 0.183261,
         "f1": 0.003268,
         "hamming": 0.002072,
-        "main_score": 0.001741,
+        "main_score": 0.183261,
         "hf_subset": "noisy",
         "languages": [
           "eng-Latn"

--- a/results/vitouphy__wav2vec2-xls-r-300m-phoneme/bf9913bf096d133cf4eca64ed75981ebf0545c9d/FSD50K.json
+++ b/results/vitouphy__wav2vec2-xls-r-300m-phoneme/bf9913bf096d133cf4eca64ed75981ebf0545c9d/FSD50K.json
@@ -71,7 +71,7 @@
         "lrap": 0.831804,
         "f1": 0.337491,
         "hamming": 0.593199,
-        "main_score": 0.000244,
+        "main_score": 0.831804,
         "hf_subset": "default",
         "languages": [
           "eng-Latn"


### PR DESCRIPTION
run using:
```
import json
from pathlib import Path

results = Path(__file__).parent / "results"
# get all json files in results
json_files = results.glob("**/*.json")

tasks = {"FSD2019Kaggle", "FSD50K", "BirdSet"}

for f in json_files:
    if f.stem in tasks:
        with f.open() as fp:
            data = json.load(fp)

        for split, scores in data["scores"].items():
            for i, score in enumerate(scores):
                data["scores"][split][i]["main_score"] = score["lrap"]
        with f.open("w") as fp:
            json.dump(data, fp, indent=2)
```

Note test will fail due to a large diff in main score, that is expected
