### PR TITLE
Add MTEB evaluation results for zhibinlan/UME-R1-7B

### DIFF
--- a/results/zhibinlan__UME-R1-7B/b5c08e3273d979e0f22445306717c39ca8d45df0/VGGSoundV.json
+++ b/results/zhibinlan__UME-R1-7B/b5c08e3273d979e0f22445306717c39ca8d45df0/VGGSoundV.json
@@ -1,0 +1,86 @@
+{
+  "dataset_revision": "a994211ca0996558ff6cbd6977b4c1749f49c889",
+  "task_name": "VGGSoundV",
+  "mteb_version": "2.13.1",
+  "scores": {
+    "test": [
+      {
+        "scores_per_experiment": [
+          {
+            "accuracy": 0.455511,
+            "f1": 0.395299,
+            "f1_weighted": 0.410082,
+            "precision": 0.420764,
+            "precision_weighted": 0.444154,
+            "recall": 0.452459,
+            "recall_weighted": 0.455511,
+            "ap": null,
+            "ap_weighted": null
+          },
+          {
+            "accuracy": 0.451466,
+            "f1": 0.381733,
+            "f1_weighted": 0.396963,
+            "precision": 0.398995,
+            "precision_weighted": 0.4239,
+            "recall": 0.446037,
+            "recall_weighted": 0.451466,
+            "ap": null,
+            "ap_weighted": null
+          },
+          {
+            "accuracy": 0.475228,
+            "f1": 0.409947,
+            "f1_weighted": 0.427431,
+            "precision": 0.423713,
+            "precision_weighted": 0.449645,
+            "recall": 0.466161,
+            "recall_weighted": 0.475228,
+            "ap": null,
+            "ap_weighted": null
+          },
+          {
+            "accuracy": 0.455235,
+            "f1": 0.392585,
+            "f1_weighted": 0.410327,
+            "precision": 0.420476,
+            "precision_weighted": 0.45389,
+            "recall": 0.452673,
+            "recall_weighted": 0.455235,
+            "ap": null,
+            "ap_weighted": null
+          },
+          {
+            "accuracy": 0.460293,
+            "f1": 0.400677,
+            "f1_weighted": 0.41497,
+            "precision": 0.415987,
+            "precision_weighted": 0.445876,
+            "recall": 0.462182,
+            "recall_weighted": 0.460293,
+            "ap": null,
+            "ap_weighted": null
+          }
+        ],
+        "accuracy": 0.459547,
+        "f1": 0.396048,
+        "f1_weighted": 0.411955,
+        "precision": 0.415987,
+        "precision_weighted": 0.443493,
+        "recall": 0.455902,
+        "recall_weighted": 0.459547,
+        "ap": NaN,
+        "ap_weighted": NaN,
+        "main_score": 0.459547,
+        "hf_subset": "default",
+        "languages": [
+          "eng-Latn"
+        ],
+        "mteb_version": "2.13.1"
+      }
+    ]
+  },
+  "evaluation_time": 46680.57957816124,
+  "kg_co2_emissions": null,
+  "date": null
+}


### PR DESCRIPTION
Models: zhibinlan/UME-R1-7B
Total results: 82
Submitted by MTEB ResultCache

<!-- Description of the PR goes here -->

### Checklist

- [ ] My model has a model sheet, report, or similar
- [ ] My model has a reference implementation in [`mteb/models/model_implementations/`](https://github.com/embeddings-benchmark/mteb/tree/main/mteb/models/model_implementations), this can be as an API. Instruction on how to add a model can be found [here](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/) 
  - [ ] No, but there is an existing PR ___
- [ ] The results submitted are obtained using the reference implementation
- [ ] My model is available, either as a publicly accessible API or publicly on e.g., Huggingface
- [ ] I *solemnly swear* that for all results submitted I have not trained on the evaluation dataset including training splits. If I have, I have disclosed it clearly.

