### PR TITLE
Add structure-aware corpus-adaptive hybrid retrieval results

### DIFF
--- a/results/mteb__structure-aware-corpus-adaptive-hybrid/1/FiQA2018.json
+++ b/results/mteb__structure-aware-corpus-adaptive-hybrid/1/FiQA2018.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "27a168819829fe9bcd655c2df245fb19452e8e06",
+  "task_name": "FiQA2018",
+  "mteb_version": "1.39.7",
+  "scores": {
+    "test": [
+      {
+        "ndcg_at_10": 0.40635911090970167,
+        "ndcg_at_100": 0.47222846601985163,
+        "map_at_10": 0.3268845670555602,
+        "map_at_100": 0.3447349112387422,
+        "recall_at_10": 0.477813159063159,
+        "recall_at_100": 0.7193389729269359,
+        "mrr_at_10": 0.48729791299235736,
+        "mrr_at_100": 0.4946114038630792,
+        "main_score": 0.40635911090970167,
+        "hf_subset": "default",
+        "languages": [
+          "eng-Latn"
+        ]
+      }
+    ]
+  },
+  "evaluation_time": 508.0,
+  "kg_co2_emissions": null
+}

--- a/results/mteb__structure-aware-corpus-adaptive-hybrid/1/NFCorpus.json
+++ b/results/mteb__structure-aware-corpus-adaptive-hybrid/1/NFCorpus.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "ec0fa4fe99da2ff19ca1214b7966684033a58814",
+  "task_name": "NFCorpus",
+  "mteb_version": "1.39.7",
+  "scores": {
+    "test": [
+      {
+        "ndcg_at_10": 0.348295769149734,
+        "ndcg_at_100": 0.3287960394947521,
+        "map_at_10": 0.25477269562795885,
+        "map_at_100": 0.1794857671206308,
+        "recall_at_10": 0.17092504109970372,
+        "recall_at_100": 0.32166205435563183,
+        "mrr_at_10": 0.5518563565777188,
+        "mrr_at_100": 0.5572398547145482,
+        "main_score": 0.348295769149734,
+        "hf_subset": "default",
+        "languages": [
+          "eng-Latn"
+        ]
+      }
+    ]
+  },
+  "evaluation_time": 33.0,
+  "kg_co2_emissions": null
+}

--- a/results/mteb__structure-aware-corpus-adaptive-hybrid/1/SCIDOCS.json
+++ b/results/mteb__structure-aware-corpus-adaptive-hybrid/1/SCIDOCS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "f8c2fcf00f625baaa80f62ec5bd9e1fff3b8ae88",
+  "task_name": "SCIDOCS",
+  "mteb_version": "1.39.7",
+  "scores": {
+    "test": [
+      {
+        "ndcg_at_10": 0.22040425198605612,
+        "ndcg_at_100": 0.3146828961370978,
+        "map_at_10": 0.13314996031746032,
+        "map_at_100": 0.15904815082805288,
+        "recall_at_10": 0.2348,
+        "recall_at_100": 0.5100833333333333,
+        "mrr_at_10": 0.3634503968253968,
+        "mrr_at_100": 0.3751717051564344,
+        "main_score": 0.22040425198605612,
+        "hf_subset": "default",
+        "languages": [
+          "eng-Latn"
+        ]
+      }
+    ]
+  },
+  "evaluation_time": 17.0,
+  "kg_co2_emissions": null
+}

--- a/results/mteb__structure-aware-corpus-adaptive-hybrid/1/SciFact.json
+++ b/results/mteb__structure-aware-corpus-adaptive-hybrid/1/SciFact.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "0228b52cf27578f30900b9e5271d331663a030d7",
+  "task_name": "SciFact",
+  "mteb_version": "1.39.7",
+  "scores": {
+    "test": [
+      {
+        "ndcg_at_10": 0.7085017706854067,
+        "ndcg_at_100": 0.7365156845646303,
+        "map_at_10": 0.6630661375661375,
+        "map_at_100": 0.6691531493884196,
+        "recall_at_10": 0.8365555555555556,
+        "recall_at_100": 0.965,
+        "mrr_at_10": 0.6731044973544974,
+        "mrr_at_100": 0.6777912036847318,
+        "main_score": 0.7085017706854067,
+        "hf_subset": "default",
+        "languages": [
+          "eng-Latn"
+        ]
+      }
+    ]
+  },
+  "evaluation_time": 47.0,
+  "kg_co2_emissions": null
+}

--- a/results/mteb__structure-aware-corpus-adaptive-hybrid/1/model_meta.json
+++ b/results/mteb__structure-aware-corpus-adaptive-hybrid/1/model_meta.json
@@ -1,0 +1,30 @@
+{
+  "name": "mteb/structure-aware-corpus-adaptive-hybrid",
+  "revision": "1",
+  "release_date": "2026-06-30",
+  "languages": [
+    "eng-Latn"
+  ],
+  "n_parameters": 22713216,
+  "n_embedding_parameters": 11720448,
+  "memory_usage_mb": 87.0,
+  "max_tokens": 256,
+  "embed_dim": 384,
+  "license": "apache-2.0",
+  "open_weights": true,
+  "public_training_code": null,
+  "public_training_data": null,
+  "framework": [
+    "Sentence Transformers",
+    "PyTorch",
+    "NumPy"
+  ],
+  "reference": "https://github.com/embeddings-benchmark/mteb",
+  "similarity_fn_name": "cosine",
+  "use_instructions": false,
+  "training_datasets": null,
+  "adapted_from": "sentence-transformers/all-MiniLM-L6-v2",
+  "modalities": [
+    "text"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds official-format local HF-MTEB results for `mteb/structure-aware-corpus-adaptive-hybrid` at revision `1`.

This results PR depends on the paired MTEB implementation PR:

- https://github.com/embeddings-benchmark/mteb/pull/4867

## Scores

All scores use `main_score = ndcg_at_10`.

| Task | main_score |
| --- | ---: |
| SciFact | 0.7085019697253156 |
| NFCorpus | 0.3482959056916576 |
| FiQA2018 | 0.4063591243963125 |
| SCIDOCS | 0.22040390291761284 |

Macro main score across these four tasks: `0.42089022568272455`.

## Local Validation

Before opening/updating this draft PR, I ran local checks on the generated files:

- JSON schema sanity check for all 4 task files
- `main_score == ndcg_at_10`
- `hf_subset == default`
- `languages == ["eng-Latn"]`
- `SUBMISSION_MANIFEST.json` kept out of the official results repo path
- `git diff --check`

## Source Runs

The result files were exported from local full-task HF-MTEB validation summaries for SciFact, NFCorpus, FiQA2018, and SCIDOCS.
