### PR TITLE
Add VisualSTS multilingual results for e5-omni 3B/7B and Tevatron OmniEmbed

### DIFF
--- a/results/Haon-Chen__e5-omni-3B/bc2c24d7596ea578d08adffd96146ed47b1e5f72/VisualSTS-b-Multilingual.json
+++ b/results/Haon-Chen__e5-omni-3B/bc2c24d7596ea578d08adffd96146ed47b1e5f72/VisualSTS-b-Multilingual.json
@@ -1,0 +1,30 @@
+{
+  "dataset_revision": "1",
+  "task_name": "VisualSTS-b-Multilingual",
+  "mteb_version": "2.12.32",
+  "scores": {
+    "test": [
+      {
+        "cosine_spearman": 0.711861,
+        "main_score": 0.711861,
+        "hf_subset": "default",
+        "languages": [
+          "por-Latn",
+          "pol-Latn",
+          "spa-Latn",
+          "eng-Latn",
+          "nld-Latn",
+          "cmn-Hans",
+          "deu-Latn",
+          "fra-Latn",
+          "ita-Latn",
+          "rus-Cyrl"
+        ],
+        "mteb_version": "2.12.32"
+      }
+    ]
+  },
+  "evaluation_time": 4544.658223390579,
+  "kg_co2_emissions": NaN,
+  "date": 1783036480.773007
+}

--- a/results/Haon-Chen__e5-omni-3B/bc2c24d7596ea578d08adffd96146ed47b1e5f72/VisualSTS17Multilingual.json
+++ b/results/Haon-Chen__e5-omni-3B/bc2c24d7596ea578d08adffd96146ed47b1e5f72/VisualSTS17Multilingual.json
@@ -1,0 +1,29 @@
+{
+  "dataset_revision": "1",
+  "task_name": "VisualSTS17Multilingual",
+  "mteb_version": "2.12.32",
+  "scores": {
+    "test": [
+      {
+        "cosine_spearman": 0.757879,
+        "main_score": 0.757879,
+        "hf_subset": "default",
+        "languages": [
+          "ara-Arab",
+          "spa-Latn",
+          "eng-Latn",
+          "nld-Latn",
+          "kor-Hang",
+          "tur-Latn",
+          "deu-Latn",
+          "fra-Latn",
+          "ita-Latn"
+        ],
+        "mteb_version": "2.12.32"
+      }
+    ]
+  },
+  "evaluation_time": 850.4188556671143,
+  "kg_co2_emissions": NaN,
+  "date": 1783036480.783328
+}

--- a/results/Haon-Chen__e5-omni-7B/ffea4ae1382fc26dc9fc337a89ced3fab58e408b/VisualSTS-b-Multilingual.json
+++ b/results/Haon-Chen__e5-omni-7B/ffea4ae1382fc26dc9fc337a89ced3fab58e408b/VisualSTS-b-Multilingual.json
@@ -1,0 +1,30 @@
+{
+  "dataset_revision": "1",
+  "task_name": "VisualSTS-b-Multilingual",
+  "mteb_version": "2.12.32",
+  "scores": {
+    "test": [
+      {
+        "cosine_spearman": 0.757094,
+        "main_score": 0.757094,
+        "hf_subset": "default",
+        "languages": [
+          "cmn-Hans",
+          "spa-Latn",
+          "rus-Cyrl",
+          "nld-Latn",
+          "eng-Latn",
+          "ita-Latn",
+          "fra-Latn",
+          "por-Latn",
+          "pol-Latn",
+          "deu-Latn"
+        ],
+        "mteb_version": "2.12.32"
+      }
+    ]
+  },
+  "evaluation_time": 5903.948524951935,
+  "kg_co2_emissions": NaN,
+  "date": 1783036484.452747
+}

--- a/results/Haon-Chen__e5-omni-7B/ffea4ae1382fc26dc9fc337a89ced3fab58e408b/VisualSTS17Multilingual.json
+++ b/results/Haon-Chen__e5-omni-7B/ffea4ae1382fc26dc9fc337a89ced3fab58e408b/VisualSTS17Multilingual.json
@@ -1,0 +1,29 @@
+{
+  "dataset_revision": "1",
+  "task_name": "VisualSTS17Multilingual",
+  "mteb_version": "2.12.32",
+  "scores": {
+    "test": [
+      {
+        "cosine_spearman": 0.789603,
+        "main_score": 0.789603,
+        "hf_subset": "default",
+        "languages": [
+          "spa-Latn",
+          "nld-Latn",
+          "eng-Latn",
+          "kor-Hang",
+          "ita-Latn",
+          "tur-Latn",
+          "ara-Arab",
+          "fra-Latn",
+          "deu-Latn"
+        ],
+        "mteb_version": "2.12.32"
+      }
+    ]
+  },
+  "evaluation_time": 1096.1081597805023,
+  "kg_co2_emissions": NaN,
+  "date": 1783036484.459967
+}

--- a/results/Tevatron__OmniEmbed-v0.1/fa8be315e74d07f563b07c0d053525de6dc7eda8/VisualSTS-b-Multilingual.json
+++ b/results/Tevatron__OmniEmbed-v0.1/fa8be315e74d07f563b07c0d053525de6dc7eda8/VisualSTS-b-Multilingual.json
@@ -1,0 +1,30 @@
+{
+  "dataset_revision": "1",
+  "task_name": "VisualSTS-b-Multilingual",
+  "mteb_version": "2.12.32",
+  "scores": {
+    "test": [
+      {
+        "cosine_spearman": 0.662109,
+        "main_score": 0.662109,
+        "hf_subset": "default",
+        "languages": [
+          "nld-Latn",
+          "deu-Latn",
+          "cmn-Hans",
+          "ita-Latn",
+          "por-Latn",
+          "fra-Latn",
+          "pol-Latn",
+          "rus-Cyrl",
+          "spa-Latn",
+          "eng-Latn"
+        ],
+        "mteb_version": "2.12.32"
+      }
+    ]
+  },
+  "evaluation_time": 7905.65470457077,
+  "kg_co2_emissions": NaN,
+  "date": 1783036498.987079
+}

--- a/results/Tevatron__OmniEmbed-v0.1/fa8be315e74d07f563b07c0d053525de6dc7eda8/VisualSTS17Multilingual.json
+++ b/results/Tevatron__OmniEmbed-v0.1/fa8be315e74d07f563b07c0d053525de6dc7eda8/VisualSTS17Multilingual.json
@@ -1,0 +1,29 @@
+{
+  "dataset_revision": "1",
+  "task_name": "VisualSTS17Multilingual",
+  "mteb_version": "2.12.32",
+  "scores": {
+    "test": [
+      {
+        "cosine_spearman": 0.738311,
+        "main_score": 0.738311,
+        "hf_subset": "default",
+        "languages": [
+          "nld-Latn",
+          "deu-Latn",
+          "ita-Latn",
+          "tur-Latn",
+          "ara-Arab",
+          "kor-Hang",
+          "fra-Latn",
+          "spa-Latn",
+          "eng-Latn"
+        ],
+        "mteb_version": "2.12.32"
+      }
+    ]
+  },
+  "evaluation_time": 720.1639180183411,
+  "kg_co2_emissions": NaN,
+  "date": 1783036498.995239
+}


### PR DESCRIPTION
(completes MIEB-lite 51/51)

<!-- Description of the PR goes here -->

### Checklist

- [ ] My model has a model sheet, report, or similar
- [ ] My model has a reference implementation in [`mteb/models/model_implementations/`](https://github.com/embeddings-benchmark/mteb/tree/main/mteb/models/model_implementations), this can be as an API. Instruction on how to add a model can be found [here](https://embeddings-benchmark.github.io/mteb/contributing/adding_a_model/) 
  - [ ] No, but there is an existing PR ___
- [ ] The results submitted are obtained using the reference implementation
- [ ] My model is available, either as a publicly accessible API or publicly on e.g., Huggingface
- [ ] I *solemnly swear* that for all results submitted I have not trained on the evaluation dataset including training splits. If I have, I have disclosed it clearly.

