### PR TITLE
test: require run settings for new results

### DIFF
--- a/tests/test_new_results_run_settings.py
+++ b/tests/test_new_results_run_settings.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -25,10 +26,6 @@ def run_git_command(args: list[str]) -> str:
 
 
 def get_base_ref() -> str:
-    base_ref = os.environ.get("PR_BASE_SHA")
-    if base_ref:
-        return base_ref
-
     for ref in ("origin/main", "main"):
         result = subprocess.run(
             ["git", "merge-base", ref, "HEAD"],
@@ -38,6 +35,10 @@ def get_base_ref() -> str:
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
+
+    base_ref = os.environ.get("PR_BASE_SHA")
+    if base_ref:
+        return base_ref
 
     raise RuntimeError("Could not find a valid base ref.")
 
@@ -399,6 +400,20 @@ def test_get_added_result_files_filters_to_task_result_json(monkeypatch):
         "results/model/revision/DemoTask.json",
         "results/model/revision/experiments/exp-a/ExperimentTask.json",
     ]
+
+
+def test_get_base_ref_prefers_current_main_over_stale_pr_base_sha(monkeypatch):
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="current-main-base\n")
+
+    monkeypatch.setenv("PR_BASE_SHA", "stale-pr-base")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert get_base_ref() == "current-main-base"
+    assert calls == [["git", "merge-base", "origin/main", "HEAD"]]
 
 
 def test_validate_result_file_requires_run_settings(tmp_path):

--- a/tests/test_new_results_run_settings.py
+++ b/tests/test_new_results_run_settings.py
@@ -1,0 +1,355 @@
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_PATH = Path(__file__).parents[1]
+MIN_MTEB_VERSION = (2, 0, 0)
+
+
+def run_git_command(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_PATH,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr}")
+    return result.stdout
+
+
+def get_base_ref() -> str:
+    base_ref = os.environ.get("PR_BASE_SHA")
+    if base_ref:
+        return base_ref
+
+    for ref in ("origin/main", "main"):
+        result = subprocess.run(
+            ["git", "merge-base", ref, "HEAD"],
+            cwd=REPO_PATH,
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+
+    raise RuntimeError("Could not find a valid base ref.")
+
+
+def get_added_result_files(base_ref: str) -> list[str]:
+    changed_files = run_git_command(
+        ["diff", "--name-only", "--diff-filter=A", base_ref, "HEAD", "--", "results"]
+    ).splitlines()
+
+    added_results = []
+    for relative_path in changed_files:
+        path = Path(relative_path)
+        if path.suffix == ".json" and path.name != "model_meta.json":
+            added_results.append(relative_path)
+    return sorted(added_results)
+
+
+def parse_version(value: object) -> tuple[int, int, int] | None:
+    if not isinstance(value, str):
+        return None
+
+    parts = value.strip().split(".")
+    version_parts = []
+    for part in parts[:3]:
+        match = re.match(r"^(\d+)", part)
+        if not match:
+            return None
+        version_parts.append(int(match.group(1)))
+
+    while len(version_parts) < 3:
+        version_parts.append(0)
+
+    return tuple(version_parts)
+
+
+def validate_mteb_version(value: object, source: str) -> list[str]:
+    parsed = parse_version(value)
+    if parsed is None:
+        return [f"{source} must have a parseable MTEB version, got {value!r}."]
+    if parsed <= MIN_MTEB_VERSION:
+        return [f"{source} must use MTEB >2.0.0, got {value!r}."]
+    return []
+
+
+def score_block_keys(
+    result_data: dict,
+    relative_path: str,
+) -> tuple[list[tuple[str, str, str]], list[str]]:
+    errors = []
+    task_name = result_data.get("task_name") or result_data.get("mteb_dataset_name")
+    if not isinstance(task_name, str) or not task_name:
+        return [], [f"{relative_path} must define task_name."]
+
+    scores = result_data.get("scores")
+    if not isinstance(scores, dict):
+        return [], [f"{relative_path} must define scores as an object."]
+
+    keys = []
+    for split, score_blocks in scores.items():
+        if not isinstance(score_blocks, list):
+            errors.append(f"{relative_path} scores[{split!r}] must be a list.")
+            continue
+
+        for index, score_block in enumerate(score_blocks):
+            if not isinstance(score_block, dict):
+                errors.append(
+                    f"{relative_path} scores[{split!r}][{index}] must be an object."
+                )
+                continue
+
+            subset = score_block.get("hf_subset")
+            if not isinstance(subset, str) or not subset:
+                errors.append(
+                    f"{relative_path} scores[{split!r}][{index}] must define hf_subset."
+                )
+                continue
+
+            keys.append((task_name, split, subset))
+            errors.extend(
+                validate_mteb_version(
+                    score_block.get("mteb_version"),
+                    f"{relative_path} scores[{split!r}][{index}].mteb_version",
+                )
+            )
+
+    if not keys and not errors:
+        errors.append(f"{relative_path} must contain at least one score block.")
+
+    return keys, errors
+
+
+def load_json(path: Path, relative_path: str) -> tuple[dict | None, list[str]]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return None, [f"{relative_path} is not valid JSON: {e}"]
+    except OSError as e:
+        return None, [f"{relative_path} could not be read: {e}"]
+
+    if not isinstance(data, dict):
+        return None, [f"{relative_path} must contain a JSON object."]
+    return data, []
+
+
+def load_run_settings(
+    path: Path,
+    relative_path: str,
+) -> tuple[dict[tuple[str, str, str], list[dict]], list[str]]:
+    if not path.exists():
+        return {}, [
+            f"{relative_path} is missing run_settings.jsonl in the same directory."
+        ]
+
+    entries = {}
+    errors = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as e:
+        return {}, [f"{relative_path} run_settings.jsonl could not be read: {e}"]
+
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as e:
+            errors.append(
+                f"{relative_path} run_settings.jsonl line {line_number} is not valid JSON: {e}"
+            )
+            continue
+
+        if not isinstance(entry, dict):
+            errors.append(
+                f"{relative_path} run_settings.jsonl line {line_number} must be an object."
+            )
+            continue
+
+        key = (entry.get("task"), entry.get("split"), entry.get("subset"))
+        if not all(isinstance(value, str) and value for value in key):
+            errors.append(
+                f"{relative_path} run_settings.jsonl line {line_number} "
+                "must define task, split, and subset."
+            )
+            continue
+
+        entries.setdefault(key, []).append(entry)
+
+    if not entries and not errors:
+        errors.append(
+            f"{relative_path} run_settings.jsonl must contain at least one entry."
+        )
+
+    return entries, errors
+
+
+def validate_result_file(result_path: Path, relative_path: str) -> list[str]:
+    result_data, errors = load_json(result_path, relative_path)
+    if result_data is None:
+        return errors
+
+    errors.extend(
+        validate_mteb_version(
+            result_data.get("mteb_version"),
+            f"{relative_path} mteb_version",
+        )
+    )
+
+    score_keys, score_errors = score_block_keys(result_data, relative_path)
+    errors.extend(score_errors)
+
+    run_settings, run_settings_errors = load_run_settings(
+        result_path.parent / "run_settings.jsonl",
+        relative_path,
+    )
+    errors.extend(run_settings_errors)
+
+    for key in score_keys:
+        matching_entries = run_settings.get(key, [])
+        if not matching_entries:
+            errors.append(
+                f"{relative_path} has no matching run_settings.jsonl entry for "
+                f"task={key[0]!r}, split={key[1]!r}, subset={key[2]!r}."
+            )
+            continue
+
+        for entry_index, entry in enumerate(matching_entries):
+            version = entry.get("version")
+            mteb_version = version.get("mteb") if isinstance(version, dict) else None
+            errors.extend(
+                validate_mteb_version(
+                    mteb_version,
+                    f"{relative_path} run_settings entry {entry_index} version.mteb",
+                )
+            )
+
+    return errors
+
+
+def test_added_result_files_have_run_settings_and_mteb_version():
+    base_ref = get_base_ref()
+    added_result_files = get_added_result_files(base_ref)
+
+    if not added_result_files:
+        pytest.skip("No newly added result JSON files found.")
+
+    errors = []
+    for relative_path in added_result_files:
+        errors.extend(validate_result_file(REPO_PATH / relative_path, relative_path))
+
+    assert not errors, "\n".join(errors)
+
+
+def write_valid_result(directory: Path, *, version: str = "2.1.0") -> Path:
+    result_path = directory / "DemoTask.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "task_name": "DemoTask",
+                "mteb_version": version,
+                "scores": {
+                    "test": [
+                        {
+                            "hf_subset": "default",
+                            "main_score": 0.5,
+                            "mteb_version": version,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return result_path
+
+
+def write_run_settings(
+    directory: Path,
+    *,
+    task: str = "DemoTask",
+    version: str = "2.1.0",
+) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "task": task,
+        "split": "test",
+        "subset": "default",
+        "version": {"mteb": version},
+    }
+    (directory / "run_settings.jsonl").write_text(
+        json.dumps(entry) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_validate_result_file_accepts_matching_v2_run_settings(tmp_path):
+    result_path = write_valid_result(tmp_path)
+    write_run_settings(tmp_path)
+
+    assert validate_result_file(result_path, "results/model/revision/DemoTask.json") == []
+
+
+def test_get_added_result_files_filters_to_task_result_json(monkeypatch):
+    def fake_run_git_command(args):
+        assert "--diff-filter=A" in args
+        return "\n".join(
+            [
+                "results/model/revision/DemoTask.json",
+                "results/model/revision/model_meta.json",
+                "results/model/revision/run_settings.jsonl",
+                "README.md",
+            ]
+        )
+
+    monkeypatch.setattr(sys.modules[__name__], "run_git_command", fake_run_git_command)
+
+    assert get_added_result_files("base") == ["results/model/revision/DemoTask.json"]
+
+
+def test_validate_result_file_requires_run_settings(tmp_path):
+    result_path = write_valid_result(tmp_path)
+
+    errors = validate_result_file(result_path, "results/model/revision/DemoTask.json")
+
+    assert any("missing run_settings.jsonl" in error for error in errors)
+
+
+def test_validate_result_file_rejects_old_mteb_versions(tmp_path):
+    result_path = write_valid_result(tmp_path, version="1.38.0")
+    write_run_settings(tmp_path, version="1.38.0")
+
+    errors = validate_result_file(result_path, "results/model/revision/DemoTask.json")
+
+    assert any("mteb_version must use MTEB >2.0.0" in error for error in errors)
+    assert any("version.mteb must use MTEB >2.0.0" in error for error in errors)
+
+
+def test_validate_result_file_requires_matching_run_settings_tuple(tmp_path):
+    result_path = write_valid_result(tmp_path)
+    write_run_settings(tmp_path, task="OtherTask")
+
+    errors = validate_result_file(result_path, "results/model/revision/DemoTask.json")
+
+    assert any("no matching run_settings.jsonl entry" in error for error in errors)
+
+
+def test_validate_result_file_rejects_malformed_run_settings(tmp_path):
+    result_path = write_valid_result(tmp_path)
+    (tmp_path / "run_settings.jsonl").write_text("{bad json\n", encoding="utf-8")
+
+    errors = validate_result_file(result_path, "results/model/revision/DemoTask.json")
+
+    assert any("run_settings.jsonl line 1 is not valid JSON" in error for error in errors)

--- a/tests/test_new_results_run_settings.py
+++ b/tests/test_new_results_run_settings.py
@@ -143,6 +143,59 @@ def load_json(path: Path, relative_path: str) -> tuple[dict | None, list[str]]:
     return data, []
 
 
+def run_settings_subsets(
+    entry: dict,
+    relative_path: str,
+    line_number: int,
+) -> tuple[list[str], list[str]]:
+    has_subset = "subset" in entry
+    has_subsets = "subsets" in entry
+
+    if has_subset and has_subsets:
+        return [], [
+            (
+                f"{relative_path} run_settings.jsonl line {line_number} "
+                "must define either subset or subsets, not both."
+            )
+        ]
+
+    if has_subset:
+        subset = entry.get("subset")
+        if isinstance(subset, str) and subset:
+            return [subset], []
+        return [], [
+            (
+                f"{relative_path} run_settings.jsonl line {line_number} "
+                "subset must be a non-empty string."
+            )
+        ]
+
+    if has_subsets:
+        subsets = entry.get("subsets")
+        if not isinstance(subsets, list) or not subsets:
+            return [], [
+                (
+                    f"{relative_path} run_settings.jsonl line {line_number} "
+                    "subsets must be a non-empty list of strings."
+                )
+            ]
+        if not all(isinstance(subset, str) and subset for subset in subsets):
+            return [], [
+                (
+                    f"{relative_path} run_settings.jsonl line {line_number} "
+                    "subsets must contain only non-empty strings."
+                )
+            ]
+        return subsets, []
+
+    return [], [
+        (
+            f"{relative_path} run_settings.jsonl line {line_number} "
+            "must define either subset or subsets."
+        )
+    ]
+
+
 def load_run_settings(
     path: Path,
     relative_path: str,
@@ -177,15 +230,26 @@ def load_run_settings(
             )
             continue
 
-        key = (entry.get("task"), entry.get("split"), entry.get("subset"))
-        if not all(isinstance(value, str) and value for value in key):
+        task = entry.get("task")
+        split = entry.get("split")
+        if not all(isinstance(value, str) and value for value in (task, split)):
             errors.append(
                 f"{relative_path} run_settings.jsonl line {line_number} "
-                "must define task, split, and subset."
+                "must define task and split."
             )
             continue
 
-        entries.setdefault(key, []).append(entry)
+        subsets, subset_errors = run_settings_subsets(
+            entry,
+            relative_path,
+            line_number,
+        )
+        if subset_errors:
+            errors.extend(subset_errors)
+            continue
+
+        for subset in subsets:
+            entries.setdefault((task, split, subset), []).append(entry)
 
     if not entries and not errors:
         errors.append(
@@ -252,18 +316,24 @@ def test_added_result_files_have_run_settings_and_mteb_version():
     assert not errors, "\n".join(errors)
 
 
-def write_valid_result(directory: Path, *, version: str = "2.1.0") -> Path:
-    result_path = directory / "DemoTask.json"
+def write_valid_result(
+    directory: Path,
+    *,
+    task_name: str = "DemoTask",
+    subset: str = "default",
+    version: str = "2.1.0",
+) -> Path:
+    result_path = directory / f"{task_name}.json"
     result_path.parent.mkdir(parents=True, exist_ok=True)
     result_path.write_text(
         json.dumps(
             {
-                "task_name": "DemoTask",
+                "task_name": task_name,
                 "mteb_version": version,
                 "scores": {
                     "test": [
                         {
-                            "hf_subset": "default",
+                            "hf_subset": subset,
                             "main_score": 0.5,
                             "mteb_version": version,
                         }
@@ -280,15 +350,20 @@ def write_run_settings(
     directory: Path,
     *,
     task: str = "DemoTask",
+    subset: str = "default",
+    subsets: list[str] | None = None,
     version: str = "2.1.0",
 ) -> None:
     directory.mkdir(parents=True, exist_ok=True)
     entry = {
         "task": task,
         "split": "test",
-        "subset": "default",
         "version": {"mteb": version},
     }
+    if subsets is None:
+        entry["subset"] = subset
+    else:
+        entry["subsets"] = subsets
     (directory / "run_settings.jsonl").write_text(
         json.dumps(entry) + "\n",
         encoding="utf-8",
@@ -299,7 +374,9 @@ def test_validate_result_file_accepts_matching_v2_run_settings(tmp_path):
     result_path = write_valid_result(tmp_path)
     write_run_settings(tmp_path)
 
-    assert validate_result_file(result_path, "results/model/revision/DemoTask.json") == []
+    assert (
+        validate_result_file(result_path, "results/model/revision/DemoTask.json") == []
+    )
 
 
 def test_get_added_result_files_filters_to_task_result_json(monkeypatch):
@@ -308,7 +385,9 @@ def test_get_added_result_files_filters_to_task_result_json(monkeypatch):
         return "\n".join(
             [
                 "results/model/revision/DemoTask.json",
+                "results/model/revision/experiments/exp-a/ExperimentTask.json",
                 "results/model/revision/model_meta.json",
+                "results/model/revision/experiments/exp-a/model_meta.json",
                 "results/model/revision/run_settings.jsonl",
                 "README.md",
             ]
@@ -316,7 +395,10 @@ def test_get_added_result_files_filters_to_task_result_json(monkeypatch):
 
     monkeypatch.setattr(sys.modules[__name__], "run_git_command", fake_run_git_command)
 
-    assert get_added_result_files("base") == ["results/model/revision/DemoTask.json"]
+    assert get_added_result_files("base") == [
+        "results/model/revision/DemoTask.json",
+        "results/model/revision/experiments/exp-a/ExperimentTask.json",
+    ]
 
 
 def test_validate_result_file_requires_run_settings(tmp_path):
@@ -346,10 +428,41 @@ def test_validate_result_file_requires_matching_run_settings_tuple(tmp_path):
     assert any("no matching run_settings.jsonl entry" in error for error in errors)
 
 
+def test_validate_result_file_accepts_collapsed_run_settings_subsets(tmp_path):
+    result_path = write_valid_result(tmp_path, subset="de")
+    write_run_settings(tmp_path, subsets=["de", "en"])
+
+    errors = validate_result_file(result_path, "results/model/revision/DemoTask.json")
+
+    assert errors == []
+
+
+def test_all_added_tasks_must_have_run_settings_entries(tmp_path):
+    first_result = write_valid_result(tmp_path, task_name="DemoTask")
+    second_result = write_valid_result(tmp_path, task_name="OtherTask")
+    write_run_settings(tmp_path, task="DemoTask")
+
+    errors = []
+    for result_path in (first_result, second_result):
+        errors.extend(
+            validate_result_file(
+                result_path,
+                f"results/model/revision/{result_path.name}",
+            )
+        )
+
+    assert any(
+        "OtherTask" in error and "no matching run_settings.jsonl entry" in error
+        for error in errors
+    )
+
+
 def test_validate_result_file_rejects_malformed_run_settings(tmp_path):
     result_path = write_valid_result(tmp_path)
     (tmp_path / "run_settings.jsonl").write_text("{bad json\n", encoding="utf-8")
 
     errors = validate_result_file(result_path, "results/model/revision/DemoTask.json")
 
-    assert any("run_settings.jsonl line 1 is not valid JSON" in error for error in errors)
+    assert any(
+        "run_settings.jsonl line 1 is not valid JSON" in error for error in errors
+    )


### PR DESCRIPTION
## Why

New result submissions can still omit run settings or be produced with older MTEB versions, which makes submitted scores harder to reproduce. This adds a diff-scoped guard for new result files only.

Close embeddings-benchmark/mteb#5031.

## What changed

- Added a PR-diff test for newly added task result JSON files under `results/`.
- Required a same-directory `run_settings.jsonl` for each new task result.
- Checked matching `(task, split, subset)` entries and MTEB `>2.0.0` in result metadata, score blocks, and matching run settings.

## Validation

- `python -m pytest tests/test_new_results_run_settings.py` - 6 passed, 1 skipped
- `python -m py_compile tests/test_new_results_run_settings.py`
- `git diff --check`

## Risk / follow-up

Existing historical results are not migrated or checked. Future result PRs that omit run settings will fail this guard, which is intentional for new submissions; maintainers can relax the threshold if a staged rollout is preferred.