### PR TITLE
fix language removal test

### DIFF
--- a/tests/git_utils.py
+++ b/tests/git_utils.py
@@ -1,0 +1,74 @@
+"""Shared git helpers for tests that compare a PR's result files against the base branch.
+
+All helpers resolve a single ``base_ref`` (see :func:`get_base_ref`) and use it for
+*both* the list of changed files and the "old" version of each file. Using two
+different refs for those two purposes is what caused the false positives in
+https://github.com/embeddings-benchmark/mteb/issues/5242.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _run_git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def get_base_ref() -> str:
+    """Return the commit that the checked-out changes should be compared against.
+
+    This is the merge-base of ``main`` and ``HEAD``, i.e. the commit on main that the
+    checked-out code actually branched off from. In CI, ``HEAD`` is GitHub's
+    ``refs/pull/N/merge`` commit whose first parent is the tip of main at the time the
+    merge commit was created; ``git merge-base`` recovers exactly that commit.
+
+    Two tempting alternatives are deliberately *not* used:
+
+    * ``github.event.pull_request.base.sha`` (``PR_BASE_SHA``) is a snapshot of main
+      taken when the PR was opened and is not refreshed when main advances. Diffing
+      against it includes every file that unrelated PRs changed on main since then.
+    * ``origin/main`` is fetched fresh on every (re-)run, while ``HEAD`` may be a
+      merge commit that was created earlier. Files updated on main in between then
+      look as if this PR reverted them.
+
+    ``PR_BASE_SHA`` is only used as a last-resort fallback when no main ref exists
+    locally (e.g. a shallow checkout).
+    """
+    for ref in ("origin/main", "main"):
+        res = _run_git("merge-base", ref, "HEAD")
+        if res.returncode == 0 and res.stdout.strip():
+            return res.stdout.strip()
+
+    pr_base_sha = os.environ.get("PR_BASE_SHA")
+    if pr_base_sha:
+        return pr_base_sha
+
+    raise RuntimeError(
+        "Could not determine the base ref: neither origin/main nor main exists "
+        "and PR_BASE_SHA is not set."
+    )
+
+
+def get_changed_json_files(base_ref: str) -> list[str]:
+    """Repo-relative paths of ``*.json`` files that differ between ``base_ref`` and ``HEAD``."""
+    res = _run_git("diff", "--name-only", base_ref, "HEAD", "--", "*.json")
+    if res.returncode != 0:
+        raise RuntimeError(f"git diff failed with code {res.returncode}: {res.stderr}")
+    return sorted(line.strip() for line in res.stdout.splitlines() if line.strip())
+
+
+def show_file_at_ref(relative_path: str, ref: str) -> str | None:
+    """Content of ``relative_path`` at ``ref``, or ``None`` if the file does not exist there."""
+    res = _run_git("show", f"{ref}:{relative_path}")
+    if res.returncode != 0:
+        return None
+    return res.stdout

--- a/tests/test_no_languages_are_removed.py
+++ b/tests/test_no_languages_are_removed.py
@@ -1,65 +1,40 @@
 import json
-import os
-import subprocess
 from collections import defaultdict
-from pathlib import Path
+
+from tests.git_utils import (
+    REPO_ROOT,
+    get_base_ref,
+    get_changed_json_files,
+    show_file_at_ref,
+)
+
+
+def get_languages(data: dict) -> dict[tuple[str, str], set[str]]:
+    langs = defaultdict(set)
+    for split, results in data.get("scores", {}).items():
+        if isinstance(results, list):
+            for r in results:
+                if isinstance(r, dict) and isinstance(r.get("languages"), list):
+                    langs[(split, r.get("hf_subset", ""))].update(r["languages"])
+    return langs
 
 
 def test_no_languages_are_removed():
-    merge_base = os.environ.get("PR_BASE_SHA")
-    if not merge_base:
-        for ref in ("origin/main", "main"):
-            res = subprocess.run(
-                ["git", "merge-base", ref, "HEAD"],
-                capture_output=True,
-                text=True,
-            )
-            if res.returncode == 0:
-                merge_base = res.stdout.strip()
-                break
-        if not merge_base:
-            raise RuntimeError("Could not find a valid base ref (neither origin/main nor main exists).")
+    # Compare every changed file against the *same* base commit that the list of
+    # changed files was computed from. See tests/git_utils.py for why this must not be
+    # PR_BASE_SHA or origin/main (embeddings-benchmark/mteb#5242).
+    base_ref = get_base_ref()
+    changed_files = get_changed_json_files(base_ref)
 
-    diff_res = subprocess.run(
-        ["git", "diff", "--name-only", merge_base, "HEAD", "*.json"],
-        capture_output=True,
-        text=True,
-    )
-    if diff_res.returncode != 0:
-        raise RuntimeError(f"git diff failed with code {diff_res.returncode}: {diff_res.stderr}")
-
-    changed_files = sorted(diff_res.stdout.splitlines())
-
-    root = Path(__file__).parent.parent
     errors = []
-
-    def get_languages(data):
-        langs = defaultdict(set)
-        for split, results in data.get("scores", {}).items():
-            if isinstance(results, list):
-                for r in results:
-                    if isinstance(r, dict) and isinstance(r.get("languages"), list):
-                        langs[(split, r.get("hf_subset", ""))].update(r["languages"])
-        return langs
-
     for f_str in changed_files:
-        filepath = root / f_str
+        filepath = REPO_ROOT / f_str
         if not filepath.exists() or filepath.name == "model_meta.json":
             continue
 
-        # Try to retrieve file from origin/main, falling back to merge_base
-        old_content = None
-        for ref in ("origin/main", merge_base):
-            res = subprocess.run(
-                ["git", "show", f"{ref}:{f_str}"],
-                capture_output=True,
-                text=True,
-            )
-            if res.returncode == 0:
-                old_content = res.stdout
-                break
-
+        old_content = show_file_at_ref(f_str, base_ref)
         if not old_content:
+            # New file, nothing could have been removed
             continue
 
         try:
@@ -70,7 +45,7 @@ def test_no_languages_are_removed():
         try:
             with filepath.open() as f:
                 new_data = json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (json.JSONDecodeError, OSError) as e:
             raise ValueError(f"Failed to load/parse new JSON file {f_str}: {e}")
 
         old_langs = get_languages(old_data)
@@ -80,11 +55,14 @@ def test_no_languages_are_removed():
         for (split, subset), old_set in old_langs.items():
             missing = old_set - new_langs.get((split, subset), set())
             if missing:
-                removed_languages[(split, subset)].extend(sorted(list(missing)))
+                removed_languages[(split, subset)].extend(sorted(missing))
 
         if removed_languages:
             sorted_keys = sorted(removed_languages.keys())
-            removed_str = ", ".join(f"{split}/{subset}: {removed_languages[(split, subset)]}" for split, subset in sorted_keys)
+            removed_str = ", ".join(
+                f"{split}/{subset}: {removed_languages[(split, subset)]}"
+                for split, subset in sorted_keys
+            )
             errors.append(f"{f_str} has had languages removed: {removed_str}")
 
     if errors:

--- a/tests/test_no_splits_are_removed.py
+++ b/tests/test_no_splits_are_removed.py
@@ -1,76 +1,55 @@
 import json
-import os
-import subprocess
 from collections import defaultdict
-from pathlib import Path
+
+from tests.git_utils import (
+    REPO_ROOT,
+    get_base_ref,
+    get_changed_json_files,
+    show_file_at_ref,
+)
+
+
+def get_splits_subsets(data: dict) -> dict[str, set[str]]:
+    return {
+        split: {r["hf_subset"] for r in results}
+        for split, results in data.get("scores", {}).items()
+    }
 
 
 def test_no_splits_are_removed():
-    # In CI on PRs, use the PR base SHA; otherwise use merge-base with main
-    pr_base_sha = os.environ.get("PR_BASE_SHA")
-
-    if pr_base_sha:
-        merge_base = pr_base_sha
-    else:
-        # Find the merge-base (common ancestor) between main and current branch
-        merge_base = subprocess.run(
-            ["git", "merge-base", "main", "HEAD"],
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-
-    # Get changed files from git diff between main and HEAD
-    result = subprocess.run(
-        ["git", "diff", "--name-only", merge_base, "HEAD", "*.json"],
-        capture_output=True,
-        text=True,
-    )
-
-    changed_files = [f.strip() for f in result.stdout.split("\n") if f.strip()]
-    root = Path(__file__).parent.parent
+    # Compare every changed file against the *same* base commit that the list of
+    # changed files was computed from. See tests/git_utils.py for why this must not be
+    # PR_BASE_SHA or origin/main (embeddings-benchmark/mteb#5242).
+    base_ref = get_base_ref()
+    changed_files = get_changed_json_files(base_ref)
 
     errors = []
     for filepath_str in changed_files:
-        filepath = root / Path(filepath_str)
+        filepath = REPO_ROOT / filepath_str
         if not filepath.exists() or filepath.name == "model_meta.json":
             continue
-        # Get the file from main branch
-        old_content = subprocess.run(
-            ["git", "show", f"origin/main:{filepath_str}"],
-            capture_output=True,
-            text=True,
-        )
 
-        if old_content.returncode != 0:
-            # New file, skip
+        old_content = show_file_at_ref(filepath_str, base_ref)
+        if not old_content:
+            # New file, nothing could have been removed
             continue
 
-        # Load old version
-        old_data = json.loads(old_content.stdout)
-
-        # Load new version
+        old_data = json.loads(old_content)
         with filepath.open("r") as f:
             new_data = json.load(f)
 
-        old_splits_subsets = {
-            split: set(r["hf_subset"] for r in results)
-            for split, results in old_data["scores"].items()
-        }
-
-        new_splits_subsets = {
-            split: set(r["hf_subset"] for r in results)
-            for split, results in new_data["scores"].items()
-        }
+        old_splits_subsets = get_splits_subsets(old_data)
+        new_splits_subsets = get_splits_subsets(new_data)
 
         removed_split_subsets = defaultdict(list)
         for split, old_subsets in old_splits_subsets.items():
-            for subset in old_subsets:
+            for subset in sorted(old_subsets):
                 if subset not in new_splits_subsets.get(split, set()):
                     removed_split_subsets[split].append(subset)
 
         if removed_split_subsets:
             errors.append(
-                f"{filepath_str} has had splits/subsets removed: {removed_split_subsets}"
+                f"{filepath_str} has had splits/subsets removed: {dict(removed_split_subsets)}"
             )
 
     if errors:

--- a/tests/test_results_diff.py
+++ b/tests/test_results_diff.py
@@ -7,43 +7,28 @@ This test module reuses functions from create_pr_results_comment.py to:
 """
 
 import json
-import os
-import sys
-import subprocess
-from pathlib import Path
+
 import pandas as pd
 import pytest
 from mteb import TaskResult
 
+from tests.git_utils import (
+    REPO_ROOT,
+    get_base_ref,
+    get_changed_json_files,
+    show_file_at_ref,
+)
+
 MTEB_SCORE_EPSILON=0.001 
-repo_path = Path(__file__).parents[1]
-
-def get_base_ref() -> str:
-    """Get the base reference for comparison (PR_BASE_SHA env var or origin/main)."""
-    return os.getenv("PR_BASE_SHA", "origin/main")
-
-def get_diff_from_main() -> list[str]:
-    differences = subprocess.run(
-        ["git", "diff", "--name-only", "origin/main...HEAD"],
-        cwd=repo_path,
-        text=True,
-        capture_output=True,
-    ).stdout.splitlines()
-
-    return differences
+repo_path = REPO_ROOT
 
 def load_json_from_git_ref(relative_path: str, git_ref: str) -> dict | None:
     """Load a JSON file from a specific git reference."""
-    result = subprocess.run(
-        ["git", "show", f"{git_ref}:{relative_path}"],
-        cwd=repo_path,
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
+    content = show_file_at_ref(relative_path, git_ref)
+    if content is None or not content.strip():
         return None
     try:
-        return json.loads(result.stdout)
+        return json.loads(content)
     except json.JSONDecodeError:
         return None
 
@@ -164,8 +149,10 @@ def test_result_diffs_within_threshold():
     Fail if any main_score delta exceeds configured thresholds.
     """
     
+    # Use the same base commit for the changed-file list and the old file contents.
+    # See tests/git_utils.py (embeddings-benchmark/mteb#5242).
     base_ref = get_base_ref()
-    differences = get_diff_from_main()
+    differences = get_changed_json_files(base_ref)
     print(differences)
     
     # Skip test if no changes found


### PR DESCRIPTION
Fixes embeddings-benchmark/mteb#5242

Problem: `test_no_languages_are_removed` / `test_no_splits_are_removed` used different git refs for "which files changed" and "old file content":

changed files: git diff PR_BASE_SHA HEAD — PR_BASE_SHA (github.event.pull_request.base.sha) is a snapshot of main from when the PR was opened and is never refreshed, so the diff includes every file unrelated PRs merged since then.
old content: origin/main, fetched fresh on each run.
On a workflow re-run, HEAD (refs/pull/N/merge) is still the original, stale merge commit while origin/main has moved on. Files updated on main in between (e.g. hotchpotch__bekko-*/PublicHealthQA.json from #667) then look like the PR reverted them — as in #659, which never touched those files.

Fix:
1. New `tests/git_utils.py:` `get_base_ref()` = git merge-base origin/main HEAD (fallback to main, then PR_BASE_SHA only as last resort). For `refs/pull/N/merge,`, this is exactly the main tip the merge commit was built on. The same commit is used for both the changed-file list and the old content.
2. `test_no_languages_are_removed.py,` `test_no_splits_are_removed.py,` `test_results_diff.py` (same stale-PR_BASE_SHA pattern) now use the shared helper; assertion logic unchanged.
3. Reproduced the #659 failure locally (stale merge commit + stale PR_BASE_SHA, newer origin/main) → now passes.
4. A PR that actually drops a subset / a language still fails as before.